### PR TITLE
Sprockets 3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-Nothing.
+- Support Sprockets v2 and v3 (Sprockets::Asset no longer to_s to a filename)
 
 ## [0.5.1] - 2015-03-30
+### Warning
+*** This version is NOT comaptible with Sprockets >= 3.***
+
 ### Fixed
 - Support for ActiveSupport (and hence, Rails) 4.2.x. Thanks, @jmarceli.
 

--- a/lib/inline_svg/finds_asset_paths.rb
+++ b/lib/inline_svg/finds_asset_paths.rb
@@ -1,7 +1,8 @@
 module InlineSvg
   class FindsAssetPaths
     def self.by_filename(filename)
-      configured_asset_finder.find_asset(filename)
+      asset = configured_asset_finder.find_asset(filename)
+      asset && asset.pathname
     end
 
     def self.configured_asset_finder

--- a/lib/inline_svg/railtie.rb
+++ b/lib/inline_svg/railtie.rb
@@ -5,9 +5,14 @@ module InlineSvg
       ActiveSupport.on_load :action_view do
         require "inline_svg/action_view/helpers"
         include InlineSvg::ActionView::Helpers
-        InlineSvg.configure do |config|
-          config.asset_finder = app.instance_variable_get(:@assets) # In most cases this will be the Sprockets::Environment instance of the Rails app.
-        end
+      end
+    end
+
+    config.after_initialize do |app|
+      InlineSvg.configure do |config|
+        # In default Rails apps, this will be a fully operational
+        # Sprockets::Environment instance
+        config.asset_finder = app.instance_variable_get(:@assets)
       end
     end
   end

--- a/spec/finds_asset_paths_spec.rb
+++ b/spec/finds_asset_paths_spec.rb
@@ -5,12 +5,12 @@ describe InlineSvg::FindsAssetPaths do
     sprockets = double('SprocketsDouble')
 
     expect(sprockets).to receive(:find_asset).with('some-file').
-      and_return('/full/path/to/some-file')
+      and_return(double(pathname: Pathname('/full/path/to/some-file')))
 
     InlineSvg.configure do |config|
       config.asset_finder = sprockets
     end
 
-    expect(InlineSvg::FindsAssetPaths.by_filename('some-file')).to eq '/full/path/to/some-file'
+    expect(InlineSvg::FindsAssetPaths.by_filename('some-file')).to eq Pathname('/full/path/to/some-file')
   end
 end


### PR DESCRIPTION
Fixes issue [#15](https://github.com/jamesmartin/inline_svg/issues/15). There were two problems:

1. It's not possible to rely on the Rails application instance containing a reference to the `Sprockets::Environment` during the `initializer` phase of our `Railtie`. Instead of attempting to access the `:@asset` instance variable during `ActiveSupport` initialization, we now wait until after the application has been fully initialized to allow the `Sprockets` railtie to do its thing.
1. From version 3+, Sprockets changed the interface of `Sprockets::Asset` instances. It's no longer possible to simply `to_s` them and expect a full path of the asset on disk, so now we use the backwards compatible `#pathname` instance method, which allows us to read the file from disk as before.

