### PR TITLE
Update inline_svg.gemspec

### DIFF
--- a/inline_svg.gemspec
+++ b/inline_svg.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.2"
 
-  spec.add_runtime_dependency "activesupport", ">= 4.1.9"
+  spec.add_runtime_dependency "activesupport", ">= 4.0.4"
   spec.add_runtime_dependency "nokogiri", "~> 1.6", '~> 1.6'
   spec.add_runtime_dependency "loofah", ">= 2.0"
 end


### PR DESCRIPTION
removes the unnecessary(?) dependency to rails 4.1