### PR TITLE
Prevent duplicate titles

### DIFF
--- a/lib/inline_svg/transform_pipeline/transformations/title.rb
+++ b/lib/inline_svg/transform_pipeline/transformations/title.rb
@@ -5,7 +5,7 @@ module InlineSvg::TransformPipeline::Transformations
       node = Nokogiri::XML::Node.new('title', doc)
       node.content = value
       doc.search('svg title').each { |node| node.remove }
-      doc.at_css('svg').children.before(node)
+      doc.at_css('svg').prepend_child(node)
       doc
     end
   end

--- a/lib/inline_svg/transform_pipeline/transformations/title.rb
+++ b/lib/inline_svg/transform_pipeline/transformations/title.rb
@@ -4,7 +4,8 @@ module InlineSvg::TransformPipeline::Transformations
       doc = Nokogiri::XML::Document.parse(doc.to_html)
       node = Nokogiri::XML::Node.new('title', doc)
       node.content = value
-      doc.at_css('svg').add_child(node)
+      doc.search('svg title').each { |node| node.remove }
+      doc.at_css('svg').children.before(node)
       doc
     end
   end

--- a/spec/transformation_pipeline/transformations/title_spec.rb
+++ b/spec/transformation_pipeline/transformations/title_spec.rb
@@ -1,0 +1,21 @@
+require 'inline_svg/transform_pipeline'
+
+describe InlineSvg::TransformPipeline::Transformations::Title do
+  it "adds a title element as the first element in the SVG document" do
+    document = Nokogiri::XML::Document.parse('<svg>Some document</svg>')
+    transformation = InlineSvg::TransformPipeline::Transformations::Title.create_with_value("Some Title")
+
+    expect(transformation.transform(document).to_html).to eq(
+      "<svg><title>Some Title</title>Some document</svg>\n"
+    )
+  end
+
+  it "overwrites the content of an existing title element" do
+    document = Nokogiri::XML::Document.parse('<svg><title>My Title</title>Some document</svg>')
+    transformation = InlineSvg::TransformPipeline::Transformations::Title.create_with_value("Some Title")
+
+    expect(transformation.transform(document).to_html).to eq(
+      "<svg><title>Some Title</title>Some document</svg>\n"
+    )
+  end
+end

--- a/spec/transformation_pipeline/transformations/title_spec.rb
+++ b/spec/transformation_pipeline/transformations/title_spec.rb
@@ -18,4 +18,13 @@ describe InlineSvg::TransformPipeline::Transformations::Title do
       "<svg><title>Some Title</title>Some document</svg>\n"
     )
   end
+
+  it "handles empty SVG documents" do
+    document = Nokogiri::XML::Document.parse('<svg></svg>')
+    transformation = InlineSvg::TransformPipeline::Transformations::Title.create_with_value("Some Title")
+
+    expect(transformation.transform(document).to_html).to eq(
+      "<svg><title>Some Title</title></svg>\n"
+    )
+  end
 end


### PR DESCRIPTION
Addresses #31.

This branch prevents the `title` transformation from creating duplicate `<title>` elements inside the SVG document. If a `<title>` element exists it will be overwritten by the new value given. E.g. `inline_svg('my_doc.svg', title: 'My Title')`.

This branch also changes the behavior of the title transformation to make sure that the `<title>` element is always the first child element of the SVG document.