### PR TITLE
Adds default value support in transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,34 @@ In this example, the following transformation would be applied to a SVG document
 <svg custom="some value">...</svg>
 ```
 
+You can also provide a default_value to the custom transformation, so even if you don't pass a value it will be triggered
+
+```ruby
+# Note that the named `attribute` will be used to pass a value to your custom transform
+InlineSvg.configure do |config|
+  config.add_custom_transformation(attribute: :my_custom_attribute, transform: MyCustomTransform, default_value: 'default value')
+end
+```
+
+The custom transformation will be triggered even if you don't pass any attribute value
+```haml
+%div
+  = inline_svg "some-document.svg"
+  = inline_svg "some-document.svg", my_custom_attribute: 'some value'
+```
+
+In this example, the following transformation would be applied to a SVG document:
+
+```xml
+<svg custom="default value">...</svg>
+```
+
+And
+
+```xml
+<svg custom="some value">...</svg>
+```
+
 ## Contributing
 
 1. Fork it ( [http://github.com/jamesmartin/inline_svg/fork](http://github.com/jamesmartin/inline_svg/fork) )

--- a/lib/inline_svg.rb
+++ b/lib/inline_svg.rb
@@ -36,7 +36,7 @@ module InlineSvg
       if incompatible_transformation?(options.fetch(:transform))
         raise InlineSvg::Configuration::Invalid.new("#{options.fetch(:transform)} should implement the .create_with_value and #transform methods")
       end
-      @custom_transformations.merge!(Hash[ *[options.fetch(:attribute, :no_attribute), options.fetch(:transform, no_transform)] ])
+      @custom_transformations.merge!(Hash[ *[options.fetch(:attribute, :no_attribute), options] ])
     end
 
     private
@@ -45,9 +45,6 @@ module InlineSvg
       !klass.is_a?(Class) || !klass.respond_to?(:create_with_value) || !klass.instance_methods.include?(:transform)
     end
 
-    def no_transform
-      InlineSvg::TransformPipeline::Transformations::NullTransformation
-    end
   end
 
   @configuration = InlineSvg::Configuration.new

--- a/lib/inline_svg/transform_pipeline/transformations.rb
+++ b/lib/inline_svg/transform_pipeline/transformations.rb
@@ -39,7 +39,7 @@ module InlineSvg::TransformPipeline::Transformations
       .values
       .select {|opt| opt[:default_value] != nil}
       .map {|opt| [opt[:attribute], opt[:default_value]]}
-      .to_h
+      .inject({}){|hash, array| hash.merge!(array[0] => array[1])}
   end
 
   def self.no_transform

--- a/lib/inline_svg/transform_pipeline/transformations.rb
+++ b/lib/inline_svg/transform_pipeline/transformations.rb
@@ -1,17 +1,17 @@
 module InlineSvg::TransformPipeline::Transformations
   def self.built_in_transformations
     {
-      nocomment: NoComment,
-      class: ClassAttribute,
-      title: Title,
-      desc: Description,
-      size: Size,
-      height: Height,
-      width: Width,
-      id: IdAttribute,
-      data: DataAttributes,
-      preserve_aspect_ratio: PreserveAspectRatio,
-      aria: AriaAttributes
+      nocomment: { transform: NoComment },
+      class: { transform: ClassAttribute },
+      title: { transform: Title },
+      desc: { transform: Description },
+      size: { transform: Size },
+      height: { transform: Height },
+      width: { transform: Width },
+      id: { transform: IdAttribute },
+      data: { transform: DataAttributes },
+      preserve_aspect_ratio: { transform: PreserveAspectRatio },
+      aria: { transform: AriaAttributes }
     }
   end
 
@@ -25,12 +25,25 @@ module InlineSvg::TransformPipeline::Transformations
 
   def self.lookup(transform_params)
     without_empty_values(transform_params).map do |key, value|
-      all_transformations.fetch(key, NullTransformation).create_with_value(value)
+      options = all_transformations.fetch(key, { transform: NullTransformation })
+      options.fetch(:transform, no_transform).create_with_value(value)
     end
   end
 
   def self.without_empty_values(params)
-    params.reject {|key, value| value.nil?}
+    all_default_values.merge(params.reject {|key, value| value.nil?})
+  end
+
+  def self.all_default_values
+    custom_transformations
+      .values
+      .select {|opt| opt[:default_value] != nil}
+      .map {|opt| [opt[:attribute], opt[:default_value]]}
+      .to_h
+  end
+
+  def self.no_transform
+    InlineSvg::TransformPipeline::Transformations::NullTransformation
   end
 end
 

--- a/lib/inline_svg/transform_pipeline/transformations.rb
+++ b/lib/inline_svg/transform_pipeline/transformations.rb
@@ -24,14 +24,14 @@ module InlineSvg::TransformPipeline::Transformations
   end
 
   def self.lookup(transform_params)
-    without_empty_values(transform_params).map do |key, value|
+    all_default_values.merge(without_empty_values(transform_params)).map do |key, value|
       options = all_transformations.fetch(key, { transform: NullTransformation })
       options.fetch(:transform, no_transform).create_with_value(value)
     end
   end
 
   def self.without_empty_values(params)
-    all_default_values.merge(params.reject {|key, value| value.nil?})
+    params.reject {|key, value| value.nil?}
   end
 
   def self.all_default_values
@@ -39,7 +39,7 @@ module InlineSvg::TransformPipeline::Transformations
       .values
       .select {|opt| opt[:default_value] != nil}
       .map {|opt| [opt[:attribute], opt[:default_value]]}
-      .inject({}){|hash, array| hash.merge!(array[0] => array[1])}
+      .inject({}) {|hash, array| hash.merge!(array[0] => array[1])}
   end
 
   def self.no_transform

--- a/spec/helpers/inline_svg_spec.rb
+++ b/spec/helpers/inline_svg_spec.rb
@@ -112,6 +112,38 @@ SVG
         end
       end
 
+      context "with custom transformations using a default value" do
+        before(:each) do
+          InlineSvg.configure do |config|
+            config.add_custom_transformation({attribute: :custom, transform: WorkingCustomTransform, default_value: 'default value'})
+          end
+        end
+
+        after(:each) do
+          InlineSvg.reset_configuration!
+        end
+
+        context "without passing the attribute value" do
+          it "applies custom transformations to the output using the default value" do
+            input_svg = '<svg></svg>'
+
+            allow(InlineSvg::AssetFile).to receive(:named).with('some-file').and_return(input_svg)
+
+            expect(helper.inline_svg('some-file')).to eq "<svg custom=\"default value\"></svg>\n"
+          end
+        end
+
+        context "passing the attribute value" do
+          it "applies custom transformations to the output" do
+            input_svg = '<svg></svg>'
+
+            allow(InlineSvg::AssetFile).to receive(:named).with('some-file').and_return(input_svg)
+
+            expect(helper.inline_svg('some-file', custom: 'some value')).to eq "<svg custom=\"some value\"></svg>\n"
+          end
+        end
+      end
+
     end
     context 'argument polimorphizm' do
       let(:argument) { double('argument') }

--- a/spec/inline_svg_spec.rb
+++ b/spec/inline_svg_spec.rb
@@ -48,7 +48,7 @@ describe InlineSvg do
           config.add_custom_transformation(attribute: :my_transform, transform: MyCustomTransform)
         end
 
-        expect(InlineSvg.configuration.custom_transformations).to eq({my_transform: MyCustomTransform})
+        expect(InlineSvg.configuration.custom_transformations).to eq({my_transform: {attribute: :my_transform, transform: MyCustomTransform}})
       end
 
       it "rejects transformations that do not implement .create_with_value" do


### PR DESCRIPTION
## Change Log
Adds default value to custom transformations

Now while adding a custom transformation you can specify a default value to the attribute using `default_value: 'value'` this way if the attribute is not set in the `inline_svg` method it'll assume the default value.

```ruby
# Note that the named `attribute` will be used to pass a value to your custom transform
InlineSvg.configure do |config|
  config.add_custom_transformation(attribute: :my_custom_attribute, transform: MyCustomTransform, default_value: 'default value')
end
```

```haml
%div
  = inline_svg "some-document.svg"
  = inline_svg "some-document.svg", my_custom_attribute: 'some value'
```