### PR TITLE
Provide a hint when .svg is omitted from the filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-- Nothing
+### Fixed
+- Provide a hint when the .svg extension is omitted from the filename
+  [#41](https://github.com/jamesmartin/inline_svg/issues/41)
 
 ## [0.9.0] - 2016-06-30
 ### Fixed

--- a/inline_svg.gemspec
+++ b/inline_svg.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
 
-  spec.add_runtime_dependency "activesupport", ">= 4.0.4"
+  spec.add_runtime_dependency "activesupport", "~> 4.0"
   spec.add_runtime_dependency "nokogiri", "~> 1.6", '~> 1.6'
   spec.add_runtime_dependency "loofah", ">= 2.0"
 end

--- a/lib/inline_svg/action_view/helpers.rb
+++ b/lib/inline_svg/action_view/helpers.rb
@@ -12,10 +12,16 @@ module InlineSvg
             InlineSvg::AssetFile.named filename
           end
         rescue InlineSvg::AssetFile::FileNotFound
-          return "<svg><!-- SVG file not found: '#{filename}' --></svg>".html_safe
+          return "<svg><!-- SVG file not found: '#{filename}' #{extension_hint(filename)}--></svg>".html_safe
         end
 
         InlineSvg::TransformPipeline.generate_html_from(svg_file, transform_params).html_safe
+      end
+
+      private
+
+      def extension_hint(filename)
+        filename.ends_with?(".svg") ? "" : "(Try adding .svg to your filename) "
       end
     end
   end

--- a/spec/helpers/inline_svg_spec.rb
+++ b/spec/helpers/inline_svg_spec.rb
@@ -17,10 +17,22 @@ describe InlineSvg::ActionView::Helpers do
     
     context "when passed the name of an SVG that does not exist" do
       it "returns an empty, html safe, SVG document as a placeholder" do
-        allow(InlineSvg::AssetFile).to receive(:named).with('some-missing-file').and_raise(InlineSvg::AssetFile::FileNotFound.new)
-        output = helper.inline_svg('some-missing-file')
-        expect(output).to eq "<svg><!-- SVG file not found: 'some-missing-file' --></svg>"
+        allow(InlineSvg::AssetFile).to receive(:named).
+          with('some-missing-file.svg').
+          and_raise(InlineSvg::AssetFile::FileNotFound.new)
+
+        output = helper.inline_svg('some-missing-file.svg')
+        expect(output).to eq "<svg><!-- SVG file not found: 'some-missing-file.svg' --></svg>"
         expect(output).to be_html_safe
+      end
+
+      it "gives a helpful hint when no .svg extension is provided in the filename" do
+        allow(InlineSvg::AssetFile).to receive(:named).
+          with('missing-file-with-no-extension').
+          and_raise(InlineSvg::AssetFile::FileNotFound.new)
+
+        output = helper.inline_svg('missing-file-with-no-extension')
+        expect(output).to eq "<svg><!-- SVG file not found: 'missing-file-with-no-extension' (Try adding .svg to your filename) --></svg>"
       end
     end
 


### PR DESCRIPTION
Addresses #41 by displaying a hint (in the embedded HTML comment) that the .svg extension is missing from the filename.