### PR TITLE
Allow for newer ActiveSupport (for Rails 5)

### DIFF
--- a/inline_svg.gemspec
+++ b/inline_svg.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
 
-  spec.add_runtime_dependency "activesupport", "~> 4.0"
+  spec.add_runtime_dependency "activesupport", ">= 4.0"
   spec.add_runtime_dependency "nokogiri", "~> 1.6", '~> 1.6'
   spec.add_runtime_dependency "loofah", ">= 2.0"
 end


### PR DESCRIPTION
Permits use with Rails 5 by loosening the ActiveSupport version a bit. Tested with a local app and didn't notice any issues, and tests passing.