### PR TITLE
Add support for the filename method from sprockets environment

### DIFF
--- a/lib/inline_svg/finds_asset_paths.rb
+++ b/lib/inline_svg/finds_asset_paths.rb
@@ -2,7 +2,7 @@ module InlineSvg
   class FindsAssetPaths
     def self.by_filename(filename)
       asset = configured_asset_finder.find_asset(filename)
-      asset && asset.pathname
+      asset.try(:pathname) || asset.try(:filename)
     end
 
     def self.configured_asset_finder

--- a/spec/finds_asset_paths_spec.rb
+++ b/spec/finds_asset_paths_spec.rb
@@ -2,16 +2,47 @@ require 'pathname'
 require_relative '../lib/inline_svg'
 
 describe InlineSvg::FindsAssetPaths do
-  it "returns fully qualified file paths from Sprockets" do
-    sprockets = double('SprocketsDouble')
+  context "when sprockets finder returns an object which supports only the pathname method" do
+    it "returns fully qualified file paths from Sprockets" do
+      sprockets = double('SprocketsDouble')
 
-    expect(sprockets).to receive(:find_asset).with('some-file').
-      and_return(double(pathname: Pathname('/full/path/to/some-file')))
+      expect(sprockets).to receive(:find_asset).with('some-file').
+        and_return(double(pathname: Pathname('/full/path/to/some-file')))
 
-    InlineSvg.configure do |config|
-      config.asset_finder = sprockets
+      InlineSvg.configure do |config|
+        config.asset_finder = sprockets
+      end
+
+      expect(InlineSvg::FindsAssetPaths.by_filename('some-file')).to eq Pathname('/full/path/to/some-file')
     end
+  end
 
-    expect(InlineSvg::FindsAssetPaths.by_filename('some-file')).to eq Pathname('/full/path/to/some-file')
+  context "when sprockets finder returns an object which supports only the filename method" do
+    it "returns fully qualified file paths from Sprockets" do
+      sprockets = double('SprocketsDouble')
+
+      expect(sprockets).to receive(:find_asset).with('some-file').
+        and_return(double(filename: Pathname('/full/path/to/some-file')))
+
+      InlineSvg.configure do |config|
+        config.asset_finder = sprockets
+      end
+
+      expect(InlineSvg::FindsAssetPaths.by_filename('some-file')).to eq Pathname('/full/path/to/some-file')
+    end
+  end
+
+  context "when asset is not found" do
+    it "returns nil" do
+      sprockets = double('SprocketsDouble')
+
+      expect(sprockets).to receive(:find_asset).with('some-file').and_return(nil)
+
+      InlineSvg.configure do |config|
+        config.asset_finder = sprockets
+      end
+
+      expect(InlineSvg::FindsAssetPaths.by_filename('some-file')).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Hi guys,

I found that after updating rails to 5.0.0 along with sprockets, the app uses `Sprockets::Environment` as assets finder, therefore, it returns object `Sprockets::Asset`which does not respond to `pathname`. I looked it up, and the method was moved to deprecated and later replaced with a new one: `filename`. This PR adds support for both methods: `pathname` & `filename`. Could you check it out, give feedback & merge? Thanks!