### PR TITLE
Preserve existing classes

### DIFF
--- a/lib/inline_svg/transform_pipeline/transformations/class_attribute.rb
+++ b/lib/inline_svg/transform_pipeline/transformations/class_attribute.rb
@@ -2,8 +2,10 @@ module InlineSvg::TransformPipeline::Transformations
   class ClassAttribute < Transformation
     def transform(doc)
       doc = Nokogiri::XML::Document.parse(doc.to_html)
-      svg = doc.at_css 'svg'
-      svg['class'] = value
+      svg = doc.at_css "svg"
+      classes = (svg["class"] || "").split(" ")
+      classes << value
+      svg["class"] = classes.join(" ")
       doc
     end
   end

--- a/spec/transformation_pipeline/transformations/class_attribute_spec.rb
+++ b/spec/transformation_pipeline/transformations/class_attribute_spec.rb
@@ -1,4 +1,4 @@
-require 'inline_svg/transform_pipeline'
+require "inline_svg/transform_pipeline"
 
 describe InlineSvg::TransformPipeline::Transformations::ClassAttribute do
   it "adds a class attribute to a SVG document" do
@@ -7,6 +7,15 @@ describe InlineSvg::TransformPipeline::Transformations::ClassAttribute do
 
     expect(transformation.transform(document).to_html).to eq(
       "<svg class=\"some-class\">Some document</svg>\n"
+    )
+  end
+
+  it "preserves existing class attributes on a SVG document" do
+    document = Nokogiri::XML::Document.parse('<svg class="existing things">Some document</svg>')
+    transformation = InlineSvg::TransformPipeline::Transformations::ClassAttribute.create_with_value("some-class")
+
+    expect(transformation.transform(document).to_html).to eq(
+      "<svg class=\"existing things some-class\">Some document</svg>\n"
     )
   end
 end

--- a/spec/transformation_pipeline/transformations/class_attribute_spec.rb
+++ b/spec/transformation_pipeline/transformations/class_attribute_spec.rb
@@ -1,0 +1,12 @@
+require 'inline_svg/transform_pipeline'
+
+describe InlineSvg::TransformPipeline::Transformations::ClassAttribute do
+  it "adds a class attribute to a SVG document" do
+    document = Nokogiri::XML::Document.parse('<svg>Some document</svg>')
+    transformation = InlineSvg::TransformPipeline::Transformations::ClassAttribute.create_with_value("some-class")
+
+    expect(transformation.transform(document).to_html).to eq(
+      "<svg class=\"some-class\">Some document</svg>\n"
+    )
+  end
+end


### PR DESCRIPTION
Addresses #44.

This branch fixes a bug where existing `class` attribute values of a SVG document would be replaced by the built-in `class` transformation. We now append the configured transform class to the existing classes.