### PR TITLE
use title/desc value as ID salt

### DIFF
--- a/lib/inline_svg/transform_pipeline/transformations/aria_attributes.rb
+++ b/lib/inline_svg/transform_pipeline/transformations/aria_attributes.rb
@@ -26,9 +26,9 @@ module InlineSvg::TransformPipeline::Transformations
 
     def element_id_for(base, element)
       if element['id'].nil?
-        InlineSvg::IdGenerator.generate(base, value)
+        InlineSvg::IdGenerator.generate(base, element.text)
       else
-        InlineSvg::IdGenerator.generate(element['id'], value)
+        InlineSvg::IdGenerator.generate(element['id'], element.text)
       end
     end
   end

--- a/spec/transformation_pipeline/transformations/aria_attributes_spec.rb
+++ b/spec/transformation_pipeline/transformations/aria_attributes_spec.rb
@@ -13,9 +13,9 @@ describe InlineSvg::TransformPipeline::Transformations::AriaAttributes do
   context "aria-labelledby attribute" do
     it "adds 'title' when a title element is present" do
       document = Nokogiri::XML::Document.parse('<svg><title>Some title</title>Some document</svg>')
-      transformation = InlineSvg::TransformPipeline::Transformations::AriaAttributes.create_with_value("some-salt")
+      transformation = InlineSvg::TransformPipeline::Transformations::AriaAttributes.create_with_value(true)
 
-      expect(InlineSvg::IdGenerator).to receive(:generate).with("title", "some-salt").
+      expect(InlineSvg::IdGenerator).to receive(:generate).with("title", "Some title").
         and_return("some-id")
 
       expect(transformation.transform(document).to_html).to eq(
@@ -25,9 +25,9 @@ describe InlineSvg::TransformPipeline::Transformations::AriaAttributes do
 
     it "adds 'desc' when a description element is present" do
       document = Nokogiri::XML::Document.parse('<svg><desc>Some description</desc>Some document</svg>')
-      transformation = InlineSvg::TransformPipeline::Transformations::AriaAttributes.create_with_value("some-salt")
+      transformation = InlineSvg::TransformPipeline::Transformations::AriaAttributes.create_with_value(true)
 
-      expect(InlineSvg::IdGenerator).to receive(:generate).with("desc", "some-salt").
+      expect(InlineSvg::IdGenerator).to receive(:generate).with("desc", "Some description").
         and_return("some-id")
 
       expect(transformation.transform(document).to_html).to eq(
@@ -37,11 +37,11 @@ describe InlineSvg::TransformPipeline::Transformations::AriaAttributes do
 
     it "adds both 'desc' and 'title' when title and description elements are present" do
       document = Nokogiri::XML::Document.parse('<svg><title>Some title</title><desc>Some description</desc>Some document</svg>')
-      transformation = InlineSvg::TransformPipeline::Transformations::AriaAttributes.create_with_value("some-salt")
+      transformation = InlineSvg::TransformPipeline::Transformations::AriaAttributes.create_with_value(true)
 
-      expect(InlineSvg::IdGenerator).to receive(:generate).with("title", "some-salt").
+      expect(InlineSvg::IdGenerator).to receive(:generate).with("title", "Some title").
         and_return("some-id")
-      expect(InlineSvg::IdGenerator).to receive(:generate).with("desc", "some-salt").
+      expect(InlineSvg::IdGenerator).to receive(:generate).with("desc", "Some description").
         and_return("some-other-id")
 
       expect(transformation.transform(document).to_html).to eq(
@@ -51,11 +51,11 @@ describe InlineSvg::TransformPipeline::Transformations::AriaAttributes do
 
     it "uses existing IDs when they exist" do
       document = Nokogiri::XML::Document.parse('<svg><title id="my-title">Some title</title><desc id="my-desc">Some description</desc>Some document</svg>')
-      transformation = InlineSvg::TransformPipeline::Transformations::AriaAttributes.create_with_value("some-salt")
+      transformation = InlineSvg::TransformPipeline::Transformations::AriaAttributes.create_with_value(true)
 
-      expect(InlineSvg::IdGenerator).to receive(:generate).with("my-title", "some-salt").
+      expect(InlineSvg::IdGenerator).to receive(:generate).with("my-title", "Some title").
         and_return("some-id")
-      expect(InlineSvg::IdGenerator).to receive(:generate).with("my-desc", "some-salt").
+      expect(InlineSvg::IdGenerator).to receive(:generate).with("my-desc", "Some description").
         and_return("some-other-id")
 
       expect(transformation.transform(document).to_html).to eq(


### PR DESCRIPTION
Generated IDs were always the same, as `value` for `aria` equals to `true` in `element_id_for`. The hash didn’t use the `title` / `desc` content, which lead to equal IDs:

given:
```
<%=
  inline_svg('test.svg', aria: true, title: 'Title 1')
%>
<%=
  inline_svg('test.svg', aria: true, title: 'Title 2')
%>
```
produced:
```
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" \
  role="img" aria-labelledby="bx6wix4t9pxpwxnohrhrmms3wexsw2o">
  <title id="bx6wix4t9pxpwxnohrhrmms3wexsw2o">Title 1</title>
</svg>
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" \
  role="img" aria-labelledby="bx6wix4t9pxpwxnohrhrmms3wexsw2o">
  <title id="bx6wix4t9pxpwxnohrhrmms3wexsw2o">Title 2</title>
</svg>
```