### PR TITLE
Dasherize data attributes

### DIFF
--- a/lib/inline_svg/transform_pipeline/transformations/data_attributes.rb
+++ b/lib/inline_svg/transform_pipeline/transformations/data_attributes.rb
@@ -4,13 +4,19 @@ module InlineSvg::TransformPipeline::Transformations
       doc = Nokogiri::XML::Document.parse(doc.to_html)
       svg = doc.at_css 'svg'
       with_valid_hash_from(self.value).each_pair do |name, data|
-        svg["data-#{name}"] = data
+        svg["data-#{dasherize(name)}"] = data
       end
       doc
     end
 
+    private
+
     def with_valid_hash_from(hash)
       Hash.try_convert(hash) || {}
+    end
+
+    def dasherize(string)
+      string.to_s.gsub(/_/, "-")
     end
   end
 end

--- a/spec/transformation_pipeline/transformations/data_attributes_spec.rb
+++ b/spec/transformation_pipeline/transformations/data_attributes_spec.rb
@@ -19,6 +19,15 @@ describe InlineSvg::TransformPipeline::Transformations::DataAttributes do
     )
   end
 
+  it "dasherizes a data attribute name with multiple parts" do
+    document = Nokogiri::XML::Document.parse('<svg>Some document</svg>')
+    transformation = InlineSvg::TransformPipeline::Transformations::DataAttributes.create_with_value({some_other_name: "value"})
+
+    expect(transformation.transform(document).to_html).to eq(
+      "<svg data-some-other-name=\"value\">Some document</svg>\n"
+    )
+  end
+
   context "when multiple data attributes are supplied" do
     it "adds data attributes to the SVG for each supplied value" do
       document = Nokogiri::XML::Document.parse('<svg>Some document</svg>')

--- a/spec/transformation_pipeline/transformations/data_attributes_spec.rb
+++ b/spec/transformation_pipeline/transformations/data_attributes_spec.rb
@@ -10,6 +10,15 @@ describe InlineSvg::TransformPipeline::Transformations::DataAttributes do
     )
   end
 
+  it "dasherizes the data attribute name" do
+    document = Nokogiri::XML::Document.parse('<svg>Some document</svg>')
+    transformation = InlineSvg::TransformPipeline::Transformations::DataAttributes.create_with_value({some_name: "value"})
+
+    expect(transformation.transform(document).to_html).to eq(
+      "<svg data-some-name=\"value\">Some document</svg>\n"
+    )
+  end
+
   context "when multiple data attributes are supplied" do
     it "adds data attributes to the SVG for each supplied value" do
       document = Nokogiri::XML::Document.parse('<svg>Some document</svg>')


### PR DESCRIPTION
Addresses issue #51.

This branch adds a `dasherize` method to the data attribute transformation to replace underscores with dashes in data attribute names.