### PR TITLE
Relax activesupport dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-- Nothing
+- Relax dependency on `ActiveSupport` to allow Rails 3 applications to use the
+  gem: [#54](https://github.com/jamesmartin/inline_svg/issues/54)
 
 ## [0.11.1] - 2016-11-22
 ### Fixed

--- a/inline_svg.gemspec
+++ b/inline_svg.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
   spec.add_development_dependency "pry"
 
-  spec.add_runtime_dependency "activesupport", ">= 4.0"
+  spec.add_runtime_dependency "activesupport", ">= 3.0"
   spec.add_runtime_dependency "nokogiri", "~> 1.6", '~> 1.6'
   spec.add_runtime_dependency "loofah", ">= 2.0"
 end


### PR DESCRIPTION
Resolves #54. This branch relaxes the gem's dependency on `ActiveSupport` to allow compatibility with Rails 3 applications. 

So long as a Rails app is using Sprockets, everything *should* be fine.

![fine](https://cloud.githubusercontent.com/assets/75904/23979625/d2705b2a-0a4e-11e7-825a-1cd0eaa151da.gif)
