### PR TITLE
Remove dependency on Loofah

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-- Nothing
+- Remove dependency on `Loofah` while maintaining basic `nocomment` transform
 
 ## [0.12.0] - 2017-03-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ key                     | description
 `id`                    | set a ID attribute on the SVG
 `class`                 | set a CSS class attribute on the SVG
 `data`                  | add data attributes to the SVG (supply as a hash)
-`size`                  | set width and height attributes on the SVG <br/> Can also be set using `height` and/or `width` attributes, which take precedence over `size` <br/> Supplied as "{Width} * {Height}" or "{Number}", so "30px*45px" becomes `width="30px"` and `height="45px"`, and "50%" becomes `width="50%"` and `height="50%"`
+`size`                  | set width and height attributes on the SVG <br/> Can also be set using `height` and/or `width` attributes, which take precedence over `size` <br/> Supplied as "{Width} * {Height}" or "{Number}", so "30px\*45px" becomes `width="30px"` and `height="45px"`, and "50%" becomes `width="50%"` and `height="50%"`
 `title`                 | add a \<title\> node inside the top level of the SVG document
 `desc`                  | add a \<desc\> node inside the top level of the SVG document
-`nocomment`             | remove comment tags (and other unsafe/unknown tags) from svg (uses the [Loofah](https://github.com/flavorjones/loofah) gem)
+`nocomment`             | remove comment tags from the SVG document
 `preserve_aspect_ratio` | adds a `preserveAspectRatio` attribute to the SVG
 `aria`                  | adds common accessibility attributes to the SVG (see [PR #34](https://github.com/jamesmartin/inline_svg/pull/34#issue-152062674) for details)
 

--- a/inline_svg.gemspec
+++ b/inline_svg.gemspec
@@ -26,5 +26,4 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activesupport", ">= 3.0"
   spec.add_runtime_dependency "nokogiri", "~> 1.6", '~> 1.6'
-  spec.add_runtime_dependency "loofah", ">= 2.0"
 end

--- a/lib/inline_svg/transform_pipeline.rb
+++ b/lib/inline_svg/transform_pipeline.rb
@@ -10,6 +10,5 @@ module InlineSvg
 end
 
 require 'nokogiri'
-require 'loofah'
 require 'inline_svg/id_generator'
 require 'inline_svg/transform_pipeline/transformations'

--- a/lib/inline_svg/transform_pipeline/transformations/no_comment.rb
+++ b/lib/inline_svg/transform_pipeline/transformations/no_comment.rb
@@ -2,8 +2,11 @@ module InlineSvg::TransformPipeline
   module Transformations
     class NoComment < Transformation
       def transform(doc)
-        doc = Loofah::HTML::DocumentFragment.parse(doc.to_html)
-        doc.scrub!(:strip)
+        doc = Nokogiri::XML::Document.parse(doc.to_html)
+        doc.xpath("//comment()").each do |comment|
+          comment.remove
+        end
+        doc
       end
     end
   end

--- a/spec/helpers/inline_svg_spec.rb
+++ b/spec/helpers/inline_svg_spec.rb
@@ -41,7 +41,7 @@ describe InlineSvg::ActionView::Helpers do
       context "and no options" do
         it "returns a html safe version of the file's contents" do
           example_file = <<-SVG
-<svg xmlns="http://www.w3.org/2000/svg" role="presentation" xml:lang="en"><!-- This is a comment --></svg>
+<svg xmlns="http://www.w3.org/2000/svg" xml:lang="en"><!-- This is a comment --></svg>
 SVG
           allow(InlineSvg::AssetFile).to receive(:named).with('some-file').and_return(example_file)
           expect(helper.inline_svg('some-file')).to eq example_file
@@ -77,7 +77,7 @@ SVG
       context "and the 'nocomment' option" do
         it "strips comments and other unknown/unsafe nodes from the output" do
           input_svg = <<-SVG
-<svg xmlns="http://www.w3.org/2000/svg" role="presentation" xml:lang="en"><!-- This is a comment --></svg>
+<svg xmlns="http://www.w3.org/2000/svg" xml:lang="en"><!-- This is a comment --></svg>
 SVG
           expected_output = <<-SVG
 <svg xmlns="http://www.w3.org/2000/svg" xml:lang="en"></svg>
@@ -90,11 +90,10 @@ SVG
       context "and all options" do
         it "applies all expected transformations to the output" do
           input_svg = <<-SVG
-<svg xmlns="http://www.w3.org/2000/svg" role="presentation" xml:lang="en"><!-- This is a comment --></svg>
+<svg xmlns="http://www.w3.org/2000/svg" xml:lang="en"><!-- This is a comment --></svg>
 SVG
           expected_output = <<-SVG
-<svg xmlns="http://www.w3.org/2000/svg" xml:lang="en"><title>A title</title>
-<desc>A description</desc></svg>
+<svg xmlns="http://www.w3.org/2000/svg" xml:lang="en"><title>A title</title><desc>A description</desc></svg>
 SVG
           allow(InlineSvg::AssetFile).to receive(:named).with('some-file').and_return(input_svg)
           expect(helper.inline_svg('some-file', title: 'A title', desc: 'A description', nocomment: true)).to eq expected_output


### PR DESCRIPTION
This branch removes the dependency on the [Loofah gem](https://github.com/flavorjones/loofah) by reimplementing a simple transform to remove comments from SVG documents.

The made this change to remove the dependency on Loofah, which is complex, full-featured, multi-purpose gem. By calling the default `scrub!` method on the SVG document we unleash *all* of Loofah's many scrubbers, which is a massive computational overhead for the problem we're trying to solve: removing comments.

Loofah was added before I introduced the custom transformation plugin feature, when it was impossible for individual users to get this functionality on their own. 

I firmly believe that having a hard dependency on such a complicated library (with all of its many dependencies) is an unnecessary burden for most users.

I still see a use-case for automatically scrubbing SVG documents before embedding them into HTML documents, however, I think that users now have the ability to make that choice and implement a simple custom transformation to achieve that goal if they want.

Technically this is not a breaking API change, but I feel that the behavior is sufficiently different that it would be unfair to make this a minor version bump, so I'm going to include this change in a long overdue version 1.0 of this gem.

/cc @jmarceli as the original author of the `nocomment` functionality. I'm not sure if you're still using this gem, or if you have an opinion, but I thought you might be interested in this change.