### PR TITLE
Configurable asset file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-- Nothing
+- Allow configurable asset file implementations
+  [#61](https://github.com/jamesmartin/inline_svg/pull/61)
 
 ## [1.0.1] - 2017-04-10
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -206,6 +206,32 @@ Transforms are applied in ascending order (lowest number first).
 ***Note***: Custom transformations are always applied *after* all built-in
 transformations, regardless of priority.
 
+## Custom asset file loader
+
+An asset file loader returns a `String` representing the SVG document given a
+filename. Custom asset loaders should be a Ruby object that responds to a
+method called `named`, that takes one argument (a string representing the
+filename of the SVG document).
+
+An simple example might look like this:
+
+```ruby
+class MyAssetFileLoader
+  def self.named(filename)
+    # ... load SVG document however you like
+    return "<svg>some document</svg>"
+  end
+end
+```
+
+Configure your custom asset file loader in an initializer like so:
+
+```ruby
+InlineSvg.configure do |config|
+  config.asset_file(MyAssetFileLoader)
+end
+```
+
 ## Contributing
 
 1. Fork it ( [http://github.com/jamesmartin/inline_svg/fork](http://github.com/jamesmartin/inline_svg/fork) )

--- a/README.md
+++ b/README.md
@@ -208,12 +208,12 @@ transformations, regardless of priority.
 
 ## Custom asset file loader
 
-An asset file loader returns a `String` representing the SVG document given a
+An asset file loader returns a `String` representing a SVG document given a
 filename. Custom asset loaders should be a Ruby object that responds to a
 method called `named`, that takes one argument (a string representing the
 filename of the SVG document).
 
-An simple example might look like this:
+A simple example might look like this:
 
 ```ruby
 class MyAssetFileLoader

--- a/lib/inline_svg.rb
+++ b/lib/inline_svg.rb
@@ -14,10 +14,24 @@ module InlineSvg
   class Configuration
     class Invalid < ArgumentError; end
 
-    attr_reader :asset_finder, :custom_transformations
+    attr_reader :asset_file, :asset_finder, :custom_transformations
 
     def initialize
       @custom_transformations = {}
+      @asset_file = InlineSvg::AssetFile
+    end
+
+    def asset_file=(custom_asset_file)
+      begin
+        method = custom_asset_file.method(:named)
+        if method.arity == 1
+          @asset_file = custom_asset_file
+        else
+          raise InlineSvg::Configuration::Invalid.new("asset_file should implement the #named method with arity 1")
+        end
+      rescue NameError
+        raise InlineSvg::Configuration::Invalid.new("asset_file should implement the #named method")
+      end
     end
 
     def asset_finder=(finder)

--- a/lib/inline_svg/action_view/helpers.rb
+++ b/lib/inline_svg/action_view/helpers.rb
@@ -9,7 +9,7 @@ module InlineSvg
           svg_file = if InlineSvg::IOResource === filename
             InlineSvg::IOResource.read filename
           else
-            InlineSvg::AssetFile.named filename
+            configured_asset_file.named filename
           end
         rescue InlineSvg::AssetFile::FileNotFound
           return "<svg><!-- SVG file not found: '#{filename}' #{extension_hint(filename)}--></svg>".html_safe
@@ -19,6 +19,10 @@ module InlineSvg
       end
 
       private
+
+      def configured_asset_file
+        InlineSvg.configuration.asset_file
+      end
 
       def extension_hint(filename)
         filename.ends_with?(".svg") ? "" : "(Try adding .svg to your filename) "

--- a/spec/inline_svg_spec.rb
+++ b/spec/inline_svg_spec.rb
@@ -13,6 +13,10 @@ class MyInvalidCustomTransformInstance
   def self.create_with_value(value); end
 end
 
+class MyCustomAssetFile
+  def self.named(filename); end
+end
+
 describe InlineSvg do
   describe "configuration" do
     context "when a block is not given" do
@@ -39,6 +43,40 @@ describe InlineSvg do
         end
 
         expect(InlineSvg.configuration.asset_finder).to eq InlineSvg::StaticAssetFinder
+      end
+    end
+
+    context "configuring a custom asset file" do
+      it "falls back to the built-in asset file implementation by deafult" do
+        expect(InlineSvg.configuration.asset_file).to eq(InlineSvg::AssetFile)
+      end
+
+      it "adds a collaborator that meets the interface specification" do
+        InlineSvg.configure do |config|
+          config.asset_file = MyCustomAssetFile
+        end
+
+        expect(InlineSvg.configuration.asset_file).to eq MyCustomAssetFile
+      end
+
+      it "rejects a collaborator that does not conform to the interface spec" do
+        bad_asset_file = double("bad_asset_file")
+
+        expect do
+          InlineSvg.configure do |config|
+            config.asset_file = bad_asset_file
+          end
+        end.to raise_error(InlineSvg::Configuration::Invalid, /asset_file should implement the #named method/)
+      end
+
+      it "rejects a collaborator that implements the correct interface with the wrong arity" do
+        bad_asset_file = double("bad_asset_file", named: nil)
+
+        expect do
+          InlineSvg.configure do |config|
+            config.asset_file = bad_asset_file
+          end
+        end.to raise_error(InlineSvg::Configuration::Invalid, /asset_file should implement the #named method with arity 1/)
       end
     end
 


### PR DESCRIPTION
This branch allows a configurable, user-supplied collaborator that must accept a filename and return a `String` representing the SVG document requested by the filename, adhering to the interface of the existing [`InlineSvg::AssetFile` class](https://github.com/jamesmartin/inline_svg/blob/6525cc5d93d1ef992efdaf7de898f9e1f6d1de7f/lib/inline_svg/asset_file.rb#L6) (E.g. a `#named` method).

By default, `InlineSvg` falls back to the default implementation that reads data from a `File`.

This functionality supports users of the gem who want more control over where their SVG assets are located. For example, it would be possible to write a custom asset file implementation that loaded all required SVG files into process memory at boot time, rather than reading from disk on every render. Equally, it would be possible to (finally) allow SVGs to be loaded from remote URLs (E.g. on S3 etc.).