### PR TITLE
Rank matched cached assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-- Nothing
+### Fixed
+- Select most exactly matching cached asset file when multiple files match
+  given asset name [#64](https://github.com/jamesmartin/inline_svg/pull/64)
 
 ## [1.2.0] - 2017-04-20
 ### Added

--- a/lib/inline_svg/cached_asset_file.rb
+++ b/lib/inline_svg/cached_asset_file.rb
@@ -31,11 +31,25 @@ module InlineSvg
     end
 
     private
-    # Internal: Finds the key for a given asset name (using a Regex).
+    # Internal: Finds the key for a given asset name (using a Regex). In the
+    # event of an ambiguous asset_name matching multiple assets, this method
+    # ranks the matches by their full file path, choosing the shortest (most
+    # exact) match over all others.
     #
-    # Returns a String representing the key for the named asset.
+    # Returns a String representing the key for the named asset or nil if there
+    # is no match.
     def key_for_asset(asset_name)
-      assets.keys.map { |k| k.to_s }.select { |k| /#{asset_name}/.match(k) }.first
+      match = all_keys_matching(asset_name).sort do |a, b|
+        a.string.size <=> b.string.size
+      end.first
+      match && match.string
+    end
+
+    # Internal: Find all potential asset keys matching the given asset name.
+    #
+    # Returns an array of MatchData objects for keys matching the asset name.
+    def all_keys_matching(asset_name)
+      assets.keys.map { |k| /(#{asset_name})/.match(k.to_s) }.compact
     end
 
     # Internal: Recursively descends through current_paths reading each file it

--- a/spec/cached_asset_file_spec.rb
+++ b/spec/cached_asset_file_spec.rb
@@ -34,6 +34,18 @@ describe InlineSvg::CachedAssetFile do
     expect(known_document_1).to eq(asset_loader.named("assets1/known-document.svg"))
   end
 
+  it "chooses the closest exact matching file when similar files exist in the same path" do
+    known_document = File.read(fixture_path.join("assets0", "known-document.svg"))
+    known_document_2 = File.read(fixture_path.join("assets0", "known-document-two.svg"))
+
+    expect(known_document).not_to eq(known_document_2)
+
+    asset_loader = InlineSvg::CachedAssetFile.new(paths: fixture_path.join("assets0"), filters: /\.svg/)
+
+    expect(asset_loader.named("known-document")).to eq(known_document)
+    expect(asset_loader.named("known-document-two")).to eq(known_document_2)
+  end
+
   it "filters wanted files by simple string matching" do
     known_document_0 = File.read(fixture_path.join("assets0", "known-document.svg"))
     known_document_1 = File.read(fixture_path.join("assets1", "known-document.svg"))

--- a/spec/files/static_assets/assets0/known-document-two.svg
+++ b/spec/files/static_assets/assets0/known-document-two.svg
@@ -1,0 +1,1 @@
+<svg>other interesting content</svg>


### PR DESCRIPTION
Addresses #63.

This branch introduces a "ranking" algorithm to `CachedAssetFile` such that when a matched asset is ambiguous (multiple matches), the most exact match is selected. This is achieved by attempting to match against all read file paths and then sorting the results by the total size of the full path and selecting the shortest.