### PR TITLE
Handle non-ASCII characters in titles

### DIFF
--- a/lib/inline_svg/transform_pipeline/transformations/transformation.rb
+++ b/lib/inline_svg/transform_pipeline/transformations/transformation.rb
@@ -19,7 +19,9 @@ module InlineSvg::TransformPipeline::Transformations
     #
     # Returns a Nokogiri::XML::Document.
     def with_svg(doc)
-      doc = Nokogiri::XML::Document.parse(doc.to_html)
+      doc = Nokogiri::XML::Document.parse(
+        doc.to_html(encoding: "UTF-8"), nil, "UTF-8"
+      )
       svg = doc.at_css "svg"
       yield svg if svg && block_given?
       doc

--- a/spec/transformation_pipeline/transformations/title_spec.rb
+++ b/spec/transformation_pipeline/transformations/title_spec.rb
@@ -27,4 +27,13 @@ describe InlineSvg::TransformPipeline::Transformations::Title do
       "<svg><title>Some Title</title></svg>\n"
     )
   end
+
+  it "handles non-ASCII characters" do
+    document = Nokogiri::XML::Document.parse('<svg>Some document</svg>')
+    transformation = InlineSvg::TransformPipeline::Transformations::Title.create_with_value("åäö")
+
+    expect(transformation.transform(document).to_html).to eq(
+      "<svg><title>åäö</title>Some document</svg>\n"
+    )
+  end
 end


### PR DESCRIPTION
Hey, thanks for a great gem!

I tried using an ö in the title of an inlined svg and noticed it got stripped from the output.

I think this is happening because `to_html` outputs HTML entity codes for these characters by default but when these are then parsed with `Nokogiri::XML::Document.parse` they get stripped out since they aren't supported in XML:

```
irb(main):006:0> Nokogiri::XML::Document.parse("<svg>ö</svg>\n")
=> #<Nokogiri::XML::Document:0x3ff16b585394 name="document" children=[#<Nokogiri::XML::Element:0x3ff16b585060 name="svg" children=[#<Nokogiri::XML::Text:0x3ff16b584e80 "ö">]>]>
irb(main):007:0> Nokogiri::XML::Document.parse("<svg>ö</svg>\n").to_html
=> "<svg>&ouml;</svg>\n"
irb(main):008:0> Nokogiri::XML::Document.parse("<svg>&ouml;</svg>\n")
=> #<Nokogiri::XML::Document:0x3ff16af2862c name="document" children=[#<Nokogiri::XML::Element:0x3ff16af282f8 name="svg">]>
```

Explicitly setting the encoding to "UTF-8" when calling `to_html` disables generating the entities:

```
irb(main):009:0> Nokogiri::XML::Document.parse("<svg>ö</svg>\n").to_html(encoding: "UTF-8")
=> "<svg>ö</svg>\n"
```

Setting the encoding to "UTF-8" when parsing the document makes sure it's implicitly set to "UTF-8" wherever `to_html` is called later.

```
irb(main):010:0> Nokogiri::XML::Document.parse("<svg>ö</svg>\n", nil, "UTF-8").to_html
=> "<svg>ö</svg>\n"
```