### PR TITLE
Add style attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ key                     | description
 :---------------------- | :----------
 `id`                    | set a ID attribute on the SVG
 `class`                 | set a CSS class attribute on the SVG
+`style`                 | set a CSS style attribute on the SVG
 `data`                  | add data attributes to the SVG (supply as a hash)
 `size`                  | set width and height attributes on the SVG <br/> Can also be set using `height` and/or `width` attributes, which take precedence over `size` <br/> Supplied as "{Width} * {Height}" or "{Number}", so "30px\*45px" becomes `width="30px"` and `height="45px"`, and "50%" becomes `width="50%"` and `height="50%"`
 `title`                 | add a \<title\> node inside the top level of the SVG document

--- a/lib/inline_svg/transform_pipeline/transformations.rb
+++ b/lib/inline_svg/transform_pipeline/transformations.rb
@@ -7,6 +7,7 @@ module InlineSvg::TransformPipeline::Transformations
       title: { transform: Title, priority: 3 },
       aria: { transform: AriaAttributes },
       class: { transform: ClassAttribute },
+      style: { transform: StyleAttribute },
       data: { transform: DataAttributes },
       height: { transform: Height },
       nocomment: { transform: NoComment },
@@ -72,6 +73,7 @@ end
 require 'inline_svg/transform_pipeline/transformations/transformation'
 require 'inline_svg/transform_pipeline/transformations/no_comment'
 require 'inline_svg/transform_pipeline/transformations/class_attribute'
+require 'inline_svg/transform_pipeline/transformations/style_attribute'
 require 'inline_svg/transform_pipeline/transformations/title'
 require 'inline_svg/transform_pipeline/transformations/description'
 require 'inline_svg/transform_pipeline/transformations/size'

--- a/lib/inline_svg/transform_pipeline/transformations/style_attribute.rb
+++ b/lib/inline_svg/transform_pipeline/transformations/style_attribute.rb
@@ -1,0 +1,11 @@
+module InlineSvg::TransformPipeline::Transformations
+  class StyleAttribute < Transformation
+    def transform(doc)
+      with_svg(doc) do |svg|
+        styles = svg["style"].to_s.split(";")
+        styles << value
+        svg["style"] = styles.join(";")
+      end
+    end
+  end
+end

--- a/spec/transformation_pipeline/transformations/style_attribute_spec.rb
+++ b/spec/transformation_pipeline/transformations/style_attribute_spec.rb
@@ -1,0 +1,26 @@
+require "inline_svg/transform_pipeline"
+
+describe InlineSvg::TransformPipeline::Transformations::ClassAttribute do
+  it "adds a style attribute to a SVG document" do
+    document = Nokogiri::XML::Document.parse('<svg>Some document</svg>')
+    transformation =
+      InlineSvg::TransformPipeline::Transformations::StyleAttribute
+        .create_with_value("padding: 10px")
+
+    expect(transformation.transform(document).to_html).to eq(
+      "<svg style=\"padding: 10px\">Some document</svg>\n"
+    )
+  end
+
+  it "preserves existing style attributes on a SVG document" do
+    xml = '<svg style="fill: red">Some document</svg>'
+    document = Nokogiri::XML::Document.parse(xml)
+    transformation =
+      InlineSvg::TransformPipeline::Transformations::StyleAttribute
+        .create_with_value("padding: 10px")
+
+    expect(transformation.transform(document).to_html).to eq(
+      "<svg style=\"fill: red;padding: 10px\">Some document</svg>\n"
+    )
+  end
+end

--- a/spec/transformation_pipeline/transformations_spec.rb
+++ b/spec/transformation_pipeline/transformations_spec.rb
@@ -15,6 +15,7 @@ describe InlineSvg::TransformPipeline::Transformations do
       transformations = InlineSvg::TransformPipeline::Transformations.lookup(
         nocomment: 'irrelevant',
         class: 'irrelevant',
+        style: 'irrelevant',
         title: 'irrelevant',
         desc: 'irrelevant',
         size: 'irrelevant',
@@ -29,6 +30,7 @@ describe InlineSvg::TransformPipeline::Transformations do
       expect(transformations.map(&:class)).to match_array([
         InlineSvg::TransformPipeline::Transformations::NoComment,
         InlineSvg::TransformPipeline::Transformations::ClassAttribute,
+        InlineSvg::TransformPipeline::Transformations::StyleAttribute,
         InlineSvg::TransformPipeline::Transformations::Title,
         InlineSvg::TransformPipeline::Transformations::Description,
         InlineSvg::TransformPipeline::Transformations::Size,


### PR DESCRIPTION
This pull request allows using a `style` attribute on SVGs.

In my application I am currently using a custom transformation, which works perfectly fine, but I think that the `style` attribute is generic enough to be included in the gem for everybody.

E.g.:

```
inline_svg(…, style: "margin-left: 15px")
```
=>

```
<svg style="margin-left: 15px">…</svg>
```

