### PR TITLE
Improve likelihood of Aria IDs being unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-- Nothing
+- Make aria ID attributes unique
+  [#77](https://github.com/jamesmartin/inline_svg/pull/77)
 
 ## [1.2.3] - 2017-08-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased][unreleased]
 - Make aria ID attributes unique
   [#77](https://github.com/jamesmartin/inline_svg/pull/77)
+- In-line CSS style attribute
+  [#71](https://github.com/jamesmartin/inline_svg/pull/71)
 
 ## [1.2.3] - 2017-08-17
 ### Fixed

--- a/lib/inline_svg/id_generator.rb
+++ b/lib/inline_svg/id_generator.rb
@@ -1,7 +1,14 @@
 module InlineSvg
   class IdGenerator
-    def self.generate(base, salt)
-      bytes = Digest::SHA1.digest("#{base}-#{salt}")
+    class Randomness
+      require "securerandom"
+      def self.call
+        SecureRandom.hex(10)
+      end
+    end
+
+    def self.generate(base, salt, randomness: Randomness)
+      bytes = Digest::SHA1.digest("#{base}-#{salt}-#{randomness.call}")
       Digest.hexencode(bytes).to_i(16).to_s(36)
     end
   end

--- a/spec/id_generator_spec.rb
+++ b/spec/id_generator_spec.rb
@@ -1,8 +1,10 @@
 require_relative '../lib/inline_svg/id_generator'
 
 describe InlineSvg::IdGenerator do
-  it "generates a hexencoded ID based on a salt" do
-    expect(InlineSvg::IdGenerator.generate("some-base", "some-salt")).
-      to eq("ksiuuy1jduycacqpoj5smn2kyt9iv02")
+  it "generates a hexencoded ID based on a salt and a random value" do
+    randomizer = -> { "some-random-value" }
+
+    expect(InlineSvg::IdGenerator.generate("some-base", "some-salt", randomness: randomizer)).
+      to eq("t2c17mkqnvopy36iccxspura7wnreqf")
   end
 end


### PR DESCRIPTION
Fixes #76.

In #39 we introduced an ID generator that we use to add the `aria-labelled-by` attribute to the SVG root element containing compounded digest values that match the `title` and `desc` elements' `id` attributes. E.g.

```xml
<svg role="img" aria-labelledby="some-id some-other-id">
  <title id="some-id">Some title</title>
  <desc id="some-other-id">Some description</desc>
  Some document
</svg>
```

The ID values are [generated based](https://github.com/jamesmartin/inline_svg/blob/2d3524df89369cb7896ffc08de4f81197364997d/lib/inline_svg/transform_pipeline/transformations/aria_attributes.rb#L24) on either the existing ID of the element and its text, or a generic string (`title` or `desc`) and the element's text value. The values are deterministic, which leads to elements with duplicate IDs if the same SVG is added to a page multiple times.

This branch adds randomness (`SecureRandom`) to the `IdGenerator` class, to effectively reduce the likelihood of ID collision to zero.

/cc @tysongach for you input on the original feature
/cc @sonniesedge for reporting the issue