### PR TITLE
Add `aria_hidden` option

### DIFF
--- a/lib/inline_svg/transform_pipeline/transformations.rb
+++ b/lib/inline_svg/transform_pipeline/transformations.rb
@@ -6,6 +6,7 @@ module InlineSvg::TransformPipeline::Transformations
       desc: { transform: Description, priority: 2 },
       title: { transform: Title, priority: 3 },
       aria: { transform: AriaAttributes },
+      aria_hidden: { transform: AriaHidden },
       class: { transform: ClassAttribute },
       style: { transform: StyleAttribute },
       data: { transform: DataAttributes },
@@ -83,3 +84,4 @@ require 'inline_svg/transform_pipeline/transformations/id_attribute'
 require 'inline_svg/transform_pipeline/transformations/data_attributes'
 require 'inline_svg/transform_pipeline/transformations/preserve_aspect_ratio'
 require 'inline_svg/transform_pipeline/transformations/aria_attributes'
+require 'inline_svg/transform_pipeline/transformations/aria_hidden'

--- a/lib/inline_svg/transform_pipeline/transformations/aria_hidden.rb
+++ b/lib/inline_svg/transform_pipeline/transformations/aria_hidden.rb
@@ -1,0 +1,9 @@
+module InlineSvg::TransformPipeline::Transformations
+  class AriaHidden < Transformation
+    def transform(doc)
+      with_svg(doc) do |svg|
+        svg["aria-hidden"] = self.value
+      end
+    end
+  end
+end

--- a/spec/helpers/inline_svg_spec.rb
+++ b/spec/helpers/inline_svg_spec.rb
@@ -119,6 +119,19 @@ SVG
         end
       end
 
+      context "and the 'aria_hidden' option" do
+        it "sets 'aria-hidden=true' in the output" do
+          input_svg = <<-SVG
+<svg xmlns="http://www.w3.org/2000/svg" xml:lang="en"></svg>
+SVG
+          expected_output = <<-SVG
+<svg xmlns="http://www.w3.org/2000/svg" xml:lang="en" aria-hidden="true"></svg>
+SVG
+          allow(InlineSvg::AssetFile).to receive(:named).with('some-file').and_return(input_svg)
+          expect(helper.inline_svg('some-file', aria_hidden: true)).to eq expected_output
+        end
+      end
+
       context "and all options" do
         it "applies all expected transformations to the output" do
           input_svg = <<-SVG


### PR DESCRIPTION
Closes [#72].

Sometimes SVGs are simply decorative and therefore should be removed
from the accessibility tree. Here’s an example:

```erb
<p>
  <%= inline_svg "checkmark-icon.svg" %>
  Success!
</p>
```

You can imagine this as a simple flash message, letting the user know
that their action succeeded. We have the word ‘Success’, preceded by a
checkmark icon to visually represent the state.

In such a situation, the icon is simply decorative; it’s repeating
content already conveyed by the word ‘Success.’ If we apply
`aria-hidden="true"` to the SVG, we can remove it from the accessibility
tree and avoid the repetition.

[#72]: https://github.com/jamesmartin/inline_svg/issues/72