### PR TITLE
Adds missing array to cached_asset_file.rb

### DIFF
--- a/lib/inline_svg/cached_asset_file.rb
+++ b/lib/inline_svg/cached_asset_file.rb
@@ -14,7 +14,7 @@ module InlineSvg
     #           Note: Specifying no filters will cache every file found in
     #           paths.
     #
-    def initialize(paths:, filters: [])
+    def initialize(paths: [], filters: [])
       @paths = Array(paths).compact.map { |p| Pathname.new(p) }
       @filters = Array(filters).map { |f| Regexp.new(f) }
       @assets = @paths.reduce({}) { |assets, p| assets.merge(read_assets(assets, p)) }


### PR DESCRIPTION
Added an array where one appears to be missing.
Causes this error in Rails 4.0.3:
```
/gems/inline_svg-1.3.0/lib/inline_svg/cached_asset_file.rb:17: syntax error, unexpected ',' (SyntaxError)
    def initialize(paths:, filters: [])
```