### PR TITLE
Improve performance when no transformations are necessary

### DIFF
--- a/lib/inline_svg/transform_pipeline/transformations.rb
+++ b/lib/inline_svg/transform_pipeline/transformations.rb
@@ -40,8 +40,11 @@ module InlineSvg::TransformPipeline::Transformations
   end
 
   def self.lookup(transform_params)
+    return [] unless transform_params.any? || custom_transformations.any?
+
+    transform_params_with_defaults = params_with_defaults(transform_params)
     all_transformations.map { |name, definition|
-      value = params_with_defaults(transform_params)[name]
+      value = transform_params_with_defaults[name]
       definition.fetch(:transform, no_transform).create_with_value(value) if value
     }.compact
   end


### PR DESCRIPTION
First of all, thank you for your work on this fantastic library!

We've recently started leveraging it very heavily on our site and we noticed a significant slowdown associated with making dozens of calls to the `inline_svg` helper in the course of rendering a page. We've implemented an in-memory cache of the icon assets themselves since we initially assumed that disk I/O was the culprit. However, we've discovered that a significant amount of the slowdown is actually caused by building up the transformation pipeline on every call to the `inline_svg` helper method.

I did some light benchmarking and was able to produce some minor performance improvements. I wanted to open this PR as a proof of concept, and see if you're open to more such contributions before I dig any deeper.

This PR includes two performance improvements:
1. When we call the `inline_svg` helper with no options, and we have no custom transformations defined, we can short circuit the transformation lookup process to speed things up. Based on my benchmarks this speeds up the most basic use case by about 2x.
1. I moved a call to `params_with_defaults(transform_params)` out of the `map` function and assigned it to a local variable. This prevents us from having to manipulate the params hash during each iteration of the loop. This only produces about a 10% speedup in my tests, however it could still amount to several milliseconds of response time when rendering an icon heavy page.

## Benchmark results
```
# BEFORE

Warming up --------------------------------------
 no transform params     1.275k i/100ms
         class param   537.000  i/100ms
class and title params 292.000  i/100ms
Calculating -------------------------------------
 no transform params     13.052k (± 4.3%) i/s -     66.300k in   5.089840s
         class param      5.377k (± 2.9%) i/s -     27.387k in   5.097945s
class and title params    2.995k (± 2.8%) i/s -     15.184k in   5.073964s

# AFTER

Warming up --------------------------------------
 no transform params     2.612k i/100ms
         class param   627.000  i/100ms
class and title params 325.000  i/100ms
Calculating -------------------------------------
 no transform params     28.826k (± 5.7%) i/s -    143.660k in   5.001568s
         class param      6.435k (± 2.7%) i/s -     32.604k in   5.070645s
class and title params    3.308k (± 2.8%) i/s -     16.575k in   5.014429s
```

## Benchmark code
```ruby
require "inline_svg"
require "benchmark/ips"

SVG_FILE = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1792 1792"><path d="M896 1664q-26 0-44-18l-624-602q-10-8-27.5-26T145 952.5 77 855 23.5 734 0 596q0-220 127-344t351-124q62 0 126.5 21.5t120 58T820 276t76 68q36-36 76-68t95.5-68.5 120-58T1314 128q224 0 351 124t127 344q0 221-229 450l-623 600q-18 18-44 18z"/></svg>'

NO_PARAMS              = {}
CLASS_PARAM            = {class: "svg-icon-fw"}
CLASS_AND_TITLE_PARAMS = {class: "svg-icon-fw", title: "my icon"}

Benchmark.ips do |x|
  x.report("no transform params") do
    InlineSvg::TransformPipeline.generate_html_from(SVG_FILE, NO_PARAMS).html_safe
  end

  x.report("class param") do
    InlineSvg::TransformPipeline.generate_html_from(SVG_FILE, CLASS_PARAM).html_safe
  end

  x.report("class and title params") do
    InlineSvg::TransformPipeline.generate_html_from(SVG_FILE, CLASS_AND_TITLE_PARAMS).html_safe
  end
end
```

## Ideas for future improvements
* If we skip parsing SVG icons with Nokogiri entirely when there are no transformations to be applied, we could speed up the basic use case by ~90x! However, this breaks some tests since the resulting SVG code is taken directly from the asset file and is no longer returned in the beautifully consistent format that Nokogiri provides. Since this could technically alter the values being returned by the helper method, it probably warrants some discussion first.
* Perhaps more of the transformation pipeline could be built and sorted upfront, thus providing better performance when we need to make a significant number of calls? This is still just a rough idea to which I haven't given enough thought. It may require some significant rearchitecting, and ultimately not be worthwhile.