### PR TITLE
Optionally raise an error when SVG file not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Prevent invalid XML names being generated via IdGenerator
   [#87](https://github.com/jamesmartin/inline_svg/issues/87)
   Thanks, [@endorfin](https://github.com/endorfin)
+- Raise error on file not found (if configured)
+  [#93](https://github.com/jamesmartin/inline_svg/issues/93)
 
 ## [1.3.1] - 2017-12-14
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -294,6 +294,15 @@ Which would instead render:
 <svg class='svg-not-found'><!-- SVG file not found: 'some-missing-file.svg' --></svg>
 ```
 
+Alternatively, `inline_svg` can be configured to raise an exception when a file
+is not found:
+
+```ruby
+InlineSvg.configure do |config|
+  config.raise_on_file_not_found = true
+end
+```
+
 ## Contributing
 
 1. Fork it ( [http://github.com/jamesmartin/inline_svg/fork](http://github.com/jamesmartin/inline_svg/fork) )

--- a/lib/inline_svg.rb
+++ b/lib/inline_svg.rb
@@ -21,6 +21,7 @@ module InlineSvg
       @custom_transformations = {}
       @asset_file = InlineSvg::AssetFile
       @svg_not_found_css_class = nil
+      @raise_on_file_not_found = false
     end
 
     def asset_file=(custom_asset_file)
@@ -59,6 +60,14 @@ module InlineSvg
         raise InlineSvg::Configuration::Invalid.new("#{options.fetch(:transform)} should implement the .create_with_value and #transform methods")
       end
       @custom_transformations.merge!(Hash[ *[options.fetch(:attribute, :no_attribute), options] ])
+    end
+
+    def raise_on_file_not_found=(value)
+      @raise_on_file_not_found = value
+    end
+
+    def raise_on_file_not_found?
+      !!@raise_on_file_not_found
     end
 
     private

--- a/lib/inline_svg/action_view/helpers.rb
+++ b/lib/inline_svg/action_view/helpers.rb
@@ -7,7 +7,8 @@ module InlineSvg
       def inline_svg(filename, transform_params={})
         begin
           svg_file = read_svg(filename)
-        rescue InlineSvg::AssetFile::FileNotFound
+        rescue InlineSvg::AssetFile::FileNotFound => error
+          raise error if InlineSvg.configuration.raise_on_file_not_found?
           return placeholder(filename) unless transform_params[:fallback].present?
 
           if transform_params[:fallback].present?

--- a/spec/helpers/inline_svg_spec.rb
+++ b/spec/helpers/inline_svg_spec.rb
@@ -20,6 +20,22 @@ describe InlineSvg::ActionView::Helpers do
         InlineSvg.reset_configuration!
       end
 
+      context "and configured to raise" do
+        it "raises an exception" do
+          InlineSvg.configure do |config|
+            config.raise_on_file_not_found = true
+          end
+
+          allow(InlineSvg::AssetFile).to receive(:named).
+            with('some-missing-file.svg').
+            and_raise(InlineSvg::AssetFile::FileNotFound.new)
+
+          expect {
+            helper.inline_svg('some-missing-file.svg')
+          }.to raise_error(InlineSvg::AssetFile::FileNotFound)
+        end
+      end
+
       it "returns an empty, html safe, SVG document as a placeholder" do
         allow(InlineSvg::AssetFile).to receive(:named).
           with('some-missing-file.svg').


### PR DESCRIPTION
Suggested in https://github.com/jamesmartin/inline_svg/issues/93.

This branch allows `inline_svg` to be configured to raise an error when an SVG file is not found, rather than including a placeholder.

```ruby
InlineSvg.configure do |config|
  config.raise_on_file_not_found = true
end
```

/cc @elalemanyo, is this what you had in mind?