### PR TITLE
Support Webpacker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-- Nothing
+### Added
+- Support for finding assets bundled by Webpacker
+  [#96](https://github.com/jamesmartin/inline_svg/pull/96)
 
 ## [1.4.0] - 2019-04-19
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Styling a SVG document with CSS for use on the web is most reliably achieved by
 [adding classes to the document and
 embedding](http://css-tricks.com/using-svg/) it inline in the HTML.
 
-This gem adds a Rails helper method (`inline_svg`) that reads an SVG document (via Sprockets, so works with the Rails Asset Pipeline), applies a CSS class attribute to the root of the document and
+This gem adds a Rails helper method (`inline_svg`) that reads an SVG document (via Sprockets or Webpacker, so works with the Rails Asset Pipeline), applies a CSS class attribute to the root of the document and
 then embeds it into a view.
 
 Inline SVG supports [Rails 3](http://weblog.rubyonrails.org/2010/8/29/rails-3-0-it-s-done/) (from [v0.12.0](https://github.com/jamesmartin/inline_svg/releases/tag/v0.12.0)), [Rails 4](http://weblog.rubyonrails.org/2013/6/25/Rails-4-0-final/) and [Rails 5](http://weblog.rubyonrails.org/2016/6/30/Rails-5-0-final/) (from [v0.10.0](https://github.com/jamesmartin/inline_svg/releases/tag/v0.10.0)).
@@ -300,6 +300,29 @@ is not found:
 ```ruby
 InlineSvg.configure do |config|
   config.raise_on_file_not_found = true
+end
+```
+
+## Sprockets and Webpacker
+
+Inline SVG supports SVGs bundled by either Sprockets or Webpacker, however, be
+aware that the gem will *always* attempt to find SVGs using Sprockts if it is
+enabled.
+
+By default, Inline SVG will use Sprockets to find SVG files if it is enabled in
+your Rails project.
+
+If you have upgraded an older Rails project from Sprockets to Webpacker and you
+no longer want to use Sprockets at all, you should disable the Asset Pipeline
+and Inline SVG will use Webpacker automatically.
+
+If you have both Sprockets *and* Webpacker enabled for some reason and you want
+Inline SVG to use Webpacker to find SVGs then you should configure the
+`asset_finder` appropriately:
+
+```ruby
+InlineSvg.configure do |config|
+  config.asset_finder = InlineSvg::WebpackAssetFinder
 end
 ```
 

--- a/lib/inline_svg.rb
+++ b/lib/inline_svg.rb
@@ -4,6 +4,7 @@ require "inline_svg/asset_file"
 require "inline_svg/cached_asset_file"
 require "inline_svg/finds_asset_paths"
 require "inline_svg/static_asset_finder"
+require "inline_svg/webpack_asset_finder"
 require "inline_svg/transform_pipeline"
 require "inline_svg/io_resource"
 

--- a/lib/inline_svg/railtie.rb
+++ b/lib/inline_svg/railtie.rb
@@ -15,7 +15,11 @@ module InlineSvg
         # Only set this when a user-configured asset finder has not been
         # configured already.
         if config.asset_finder.nil?
-          config.asset_finder = app.instance_variable_get(:@assets)
+          if assets = app.instance_variable_get(:@assets)
+            config.asset_finder = assets
+          elsif defined?(Webpacker)
+            config.asset_finder = InlineSvg::WebpackAssetFinder
+          end
         end
       end
     end

--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -1,0 +1,19 @@
+module InlineSvg
+  class WebpackAssetFinder
+    def self.find_asset(filename)
+      new(filename)
+    end
+
+    def initialize(filename)
+      @filename = filename
+    end
+
+    def pathname
+      public_path = Webpacker.config.public_path
+      file_path = Webpacker.instance.manifest.lookup(@filename)
+      return unless public_path && file_path
+
+      File.join(public_path, file_path)
+    end
+  end
+end


### PR DESCRIPTION
Raised in https://github.com/jamesmartin/inline_svg/issues/95 and https://github.com/jamesmartin/inline_svg/issues/91. `inline_svg` currently relies either on Sprockets or a naive static asset finder that just looks for assets in the configured assets directory.

This branch enables the gem to be automatically configured with a new kind of asset finder, `WebpackAssetFinder`, which uses the `Webpacker` gem to locate the SVGs on disk.

Note: To make this work automatically it's necessary to completely disable Sprockets in your Rails app. If you can't do that for some reason, then manually configure the `WebpackAssetFinder` like so:

```ruby
InlineSvg.configure do |config|
  config.asset_finder = InlineSvg::WebpackAssetFinder
end
``` 