### PR TITLE
Added new method to check if path starts with media or add it

### DIFF
--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -10,10 +10,19 @@ module InlineSvg
 
     def pathname
       public_path = Webpacker.config.public_path
-      file_path = Webpacker.instance.manifest.lookup(@filename)
+      file_path = resolve_path_to(@filename)
       return unless public_path && file_path
 
       File.join(public_path, file_path)
+    end
+
+    private
+
+    def resolve_path_to(name)
+      path = name.starts_with?("media/") ? name : "media/#{name}"
+      Webpacker.instance.manifest.lookup(path)
+    rescue
+      Webpacker.instance.manifest.lookup(name)
     end
   end
 end


### PR DESCRIPTION
At this time the `Webpacker.manifest.lookup` check the correct path of the file. If you not specify the path prepended with `media`, the **Webpacker** return **nil**.

I've added a new method to check if the filename starts with **media**, otherwise add it.