### PR TITLE
Modify WebpackAssetFinder to serve file from dev server if one is running

### DIFF
--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -1,3 +1,5 @@
+require 'open-uri'
+
 module InlineSvg
   class WebpackAssetFinder
     def self.find_asset(filename)


### PR DESCRIPTION
The new `InlineSvg::WebpackAssetFinder` will only serve up the file if it is living in public/. These changes allow SVGs to be served from the dev server. 

You still have to opt in to the webpack asset finder. Tested with Rails 6.0.