### PR TITLE
Modify WebpackAssetFinder to serve file from dev server if one is running (with fixes)

### DIFF
--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -9,11 +9,29 @@ module InlineSvg
     end
 
     def pathname
-      public_path = Webpacker.config.public_path
       file_path = Webpacker.instance.manifest.lookup(@filename)
-      return unless public_path && file_path
+      return unless file_path
 
-      File.join(public_path, file_path)
+      if Webpacker.dev_server.running?
+        asset = Net::HTTP.get(Webpacker.dev_server.host, file_path, Webpacker.dev_server.port)
+
+        begin
+          Tempfile.new(file_path).tap do |file|
+            file.binmode
+            file.write(asset)
+            file.rewind
+          end
+        rescue StandardError => e
+          Rails.logger.error "Error creating tempfile: #{e}"
+          raise
+        end
+
+      else
+        public_path = Webpacker.config.public_path
+        return unless public_path
+
+        File.join(public_path, file_path)
+      end
     end
   end
 end


### PR DESCRIPTION
Building off of #101, this allows the gem to pick up new SVGs automatically when used with Webpacker and webpack-dev-server. This is much better than the previous situation, which required running `rake assets:precompile` to get new icons to load in development.

I've added @moxie as a coauthor of this commit. but If you'd rather have me rebase this branch to include the commits from #101, I can do that.