### PR TITLE
Fix "EOFError error" when using webpack dev server over HTTPS

### DIFF
--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -34,7 +34,7 @@ module InlineSvg
           file.rewind
         end
       rescue StandardError => e
-        Rails.logger.error "Error creating tempfile: #{e}"
+        Rails.logger.error "[inline_svg] Error creating tempfile for #{@filename}: #{e}"
         raise
       end
     end
@@ -45,6 +45,9 @@ module InlineSvg
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
       http.request(Net::HTTP::Get.new(file_path)).body
+    rescue StandardError => e
+      Rails.logger.error "[inline_svg] Error fetching #{@filename} from webpack-dev-server: #{e}"
+      raise
     end
   end
 end

--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -6,19 +6,16 @@ module InlineSvg
 
     def initialize(filename)
       @filename = filename
+      @asset_path = Webpacker.manifest.lookup(@filename)
     end
 
     def pathname
-      file_path = Webpacker.instance.manifest.lookup(@filename)
-      return unless file_path
+      return if @asset_path.blank?
 
       if Webpacker.dev_server.running?
-        dev_server_asset(file_path)
-      else
-        public_path = Webpacker.config.public_path
-        return unless public_path
-
-        File.join(public_path, file_path)
+        dev_server_asset(@asset_path)
+      elsif Webpacker.config.public_path.present?
+        File.join(Webpacker.config.public_path, @asset_path)
       end
     end
 

--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -13,7 +13,10 @@ module InlineSvg
       return unless file_path
 
       if Webpacker.dev_server.running?
-        asset = Net::HTTP.get(Webpacker.dev_server.host, file_path, Webpacker.dev_server.port)
+        http = Net::HTTP.new(Webpacker.dev_server.host, Webpacker.dev_server.port)
+        http.use_ssl = Webpacker.dev_server.https?
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        asset = http.request(Net::HTTP::Get.new(file_path)).body
 
         begin
           Tempfile.new(file_path).tap do |file|

--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -13,28 +13,38 @@ module InlineSvg
       return unless file_path
 
       if Webpacker.dev_server.running?
-        http = Net::HTTP.new(Webpacker.dev_server.host, Webpacker.dev_server.port)
-        http.use_ssl = Webpacker.dev_server.https?
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        asset = http.request(Net::HTTP::Get.new(file_path)).body
-
-        begin
-          Tempfile.new(file_path).tap do |file|
-            file.binmode
-            file.write(asset)
-            file.rewind
-          end
-        rescue StandardError => e
-          Rails.logger.error "Error creating tempfile: #{e}"
-          raise
-        end
-
+        dev_server_asset(file_path)
       else
         public_path = Webpacker.config.public_path
         return unless public_path
 
         File.join(public_path, file_path)
       end
+    end
+
+    private
+
+    def dev_server_asset(file_path)
+      asset = fetch_from_dev_server(file_path)
+
+      begin
+        Tempfile.new(file_path).tap do |file|
+          file.binmode
+          file.write(asset)
+          file.rewind
+        end
+      rescue StandardError => e
+        Rails.logger.error "Error creating tempfile: #{e}"
+        raise
+      end
+    end
+
+    def fetch_from_dev_server(file_path)
+      http = Net::HTTP.new(Webpacker.dev_server.host, Webpacker.dev_server.port)
+      http.use_ssl = Webpacker.dev_server.https?
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+      http.request(Net::HTTP::Get.new(file_path)).body
     end
   end
 end


### PR DESCRIPTION
This PR fixes an `EOFError: end of file reached` error that occurs when running `webpack-dev-server` over HTTPS (related to the recent changes introduced in #111).
