### PR TITLE
Make helpers thread-safe

### DIFF
--- a/lib/inline_svg/action_view/helpers.rb
+++ b/lib/inline_svg/action_view/helpers.rb
@@ -69,11 +69,9 @@ module InlineSvg
       end
 
       def with_asset_finder(asset_finder)
-        initial_asset_finder = InlineSvg.configuration.asset_finder
-
-        InlineSvg.configuration.asset_finder = asset_finder
+        Thread.current[:inline_svg_asset_finder] = asset_finder
         output = yield
-        InlineSvg.configuration.asset_finder = initial_asset_finder
+        Thread.current[:inline_svg_asset_finder] = nil
 
         output
       end

--- a/lib/inline_svg/finds_asset_paths.rb
+++ b/lib/inline_svg/finds_asset_paths.rb
@@ -6,7 +6,7 @@ module InlineSvg
     end
 
     def self.configured_asset_finder
-      InlineSvg.configuration.asset_finder
+      Thread.current[:inline_svg_asset_finder] || InlineSvg.configuration.asset_finder
     end
   end
 end


### PR DESCRIPTION
Fixes #112.

tl;dr — using both `inline_svg_tag` and `inline_svg_pack_tag` is not thread-safe because multiple threads could be modifying `InlineSvg.configuration.asset_finder` (a global variable) simultaneously. This pull request uses thread-local variables to swap the current asset finder, rather than change the global variable directly.

Threads kinda make my head spin, so gotchas & feedback are appreciated 🙏 
