### PR TITLE
Escape filename to avoid XSS from malicious input

### DIFF
--- a/lib/inline_svg/action_view/helpers.rb
+++ b/lib/inline_svg/action_view/helpers.rb
@@ -55,7 +55,7 @@ module InlineSvg
 
       def placeholder(filename)
         css_class = InlineSvg.configuration.svg_not_found_css_class
-        not_found_message = "'#{filename}' #{extension_hint(filename)}"
+        not_found_message = "'#{ERB::Util.html_escape_once(filename)}' #{extension_hint(filename)}"
 
         if css_class.nil?
           return "<svg><!-- SVG file not found: #{not_found_message}--></svg>".html_safe

--- a/spec/helpers/inline_svg_spec.rb
+++ b/spec/helpers/inline_svg_spec.rb
@@ -46,6 +46,17 @@ describe InlineSvg::ActionView::Helpers do
         expect(output).to be_html_safe
       end
 
+      it "escapes malicious input" do
+        malicious = "--></svg><script>alert(1)</script><svg>.svg"
+        allow(InlineSvg::AssetFile).to receive(:named).
+          with(malicious).
+          and_raise(InlineSvg::AssetFile::FileNotFound.new)
+
+        output = helper.send(helper_method, malicious)
+        expect(output).to eq "<svg><!-- SVG file not found: '#{ERB::Util.html_escape_once(malicious)}' --></svg>"
+        expect(output).to be_html_safe
+      end
+
       it "gives a helpful hint when no .svg extension is provided in the filename" do
         allow(InlineSvg::AssetFile).to receive(:named).
           with('missing-file-with-no-extension').


### PR DESCRIPTION
Because:

* If user input is provided for the file name (as in rendering an SVG based on a URL parameter), the blanket marking of the SVG output as HTML-safe exposes an app to an XSS attack in the comment listing the file that was not found.
* This happened in our app, which we resolved by adding a whitelist to check if the SVG file existed before calling `inline_svg`, but it feels safer to have the gem handle this better from the get-go.

Solution:

* HTML-escape the filename rendering the comment that it was not found.
* I considered some alternate solutions like using `content_tag` to render the SVG rather than a raw string, but this felt like a smaller change.