### PR TITLE
Improve CachedAssetFile

### DIFF
--- a/lib/inline_svg/cached_asset_file.rb
+++ b/lib/inline_svg/cached_asset_file.rb
@@ -18,6 +18,7 @@ module InlineSvg
       @paths = Array(paths).compact.map { |p| Pathname.new(p) }
       @filters = Array(filters).map { |f| Regexp.new(f) }
       @assets = @paths.reduce({}) { |assets, p| assets.merge(read_assets(assets, p)) }
+      @sorted_asset_keys = assets.keys.sort { |a, b| a.size <=> b.size }
     end
 
     # Public: Finds the named asset and returns the contents as a string.
@@ -39,17 +40,7 @@ module InlineSvg
     # Returns a String representing the key for the named asset or nil if there
     # is no match.
     def key_for_asset(asset_name)
-      match = all_keys_matching(asset_name).sort do |a, b|
-        a.string.size <=> b.string.size
-      end.first
-      match && match.string
-    end
-
-    # Internal: Find all potential asset keys matching the given asset name.
-    #
-    # Returns an array of MatchData objects for keys matching the asset name.
-    def all_keys_matching(asset_name)
-      assets.keys.map { |k| /(#{asset_name})/.match(k.to_s) }.compact
+      @sorted_asset_keys.find { |k| k.include?(asset_name) }
     end
 
     # Internal: Recursively descends through current_paths reading each file it


### PR DESCRIPTION
Closes #108

Some speed improvements for the CachedAssetFile class. Doing the key length comparisons once and removing the generated regexes drastically sped up the implementation.

Here are the benchmarks

```ruby
Benchmark.ips do |x|
  x.report("original_cached")    { cached.named(svgs.sample) }
  x.report("noncached") { noncached.named(svgs.sample) }
  x.report("new_cached") { supercached.named(svgs.sample) }

  x.compare!
end
```
```
Warming up --------------------------------------
     original_cached    35.000  i/100ms
           noncached    82.000  i/100ms
          new_cached     3.024k i/100ms
Calculating -------------------------------------
     original_cached    383.179  (±15.9%) i/s -      1.890k in   5.088049s
           noncached      1.041k (±18.2%) i/s -      5.002k in   5.022027s
          new_cached     30.145k (±15.6%) i/s -    145.152k in   5.043947s

Comparison:
          new_cached:    30145.5 i/s
           noncached:     1040.6 i/s - 28.97x  slower
     original_cached:      383.2 i/s - 78.67x  slower
```

This isn't a perfect benchmark (it's using `.sample`), but the cache is clearly faster in the new implementation. 