### PR TITLE
removes slashes from Tempfile's name on WebpackAssetFinder

### DIFF
--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -25,7 +25,7 @@ module InlineSvg
       asset = fetch_from_dev_server(file_path)
 
       begin
-        Tempfile.new(file_path).tap do |file|
+        Tempfile.new(file_path.gsub('/', '_')).tap do |file|
           file.binmode
           file.write(asset)
           file.rewind


### PR DESCRIPTION
For some reason there can't be slashes on a Tempfile name. It returns an error because it seem to try to open a file instead of creating one.

This seem's to be causing the issue described on #110.