### PR TITLE
Fix: correct asset path for webpacker 6 when using an asset host

### DIFF
--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -6,7 +6,7 @@ module InlineSvg
 
     def initialize(filename)
       @filename = filename
-      @asset_path = Webpacker.manifest.lookup(@filename)
+      @asset_path = URI(Webpacker.manifest.lookup(@filename)).path
     end
 
     def pathname


### PR DESCRIPTION
Webpacker 6 is still in beta but some people are already using it.

When using an asset host, `Webpacker.manifest.lookup` now returns the full path including the host, which then breaks `inline_svg` This PR fixes it, I tested it in production.

This probably needs a spec but I'm unfamiliar with the codebase, If you give me some pointers I'd be happy to add one.