### PR TITLE
Remove deprecation warning for inline_svg, as we intend to keep it in 2.0

### DIFF
--- a/lib/inline_svg/action_view/helpers.rb
+++ b/lib/inline_svg/action_view/helpers.rb
@@ -17,10 +17,6 @@ module InlineSvg
       end
 
       def inline_svg(filename, transform_params={})
-        ActiveSupport::Deprecation.warn(
-          '`inline_svg` is deprecated and will be removed from inline_svg 2.0 (use `inline_svg_tag` or `inline_svg_pack_tag` instead)'
-        )
-
         render_inline_svg(filename, transform_params)
       end
 


### PR DESCRIPTION
As discussed in https://github.com/jamesmartin/inline_svg/issues/105 

We intend to keep inline_svg as the default method, and instead be able to configure if it should point to sprockets or webpacker to avoid defining in respective view files if you use sprockets or webpacker, and having to change all my svg view code if you change from one to the other.

Thus, the deprecation warning in the 1.x branch is unwarranted.

