### PR TITLE
Add support for Propshaft

### DIFF
--- a/lib/inline_svg.rb
+++ b/lib/inline_svg.rb
@@ -3,6 +3,7 @@ require "inline_svg/action_view/helpers"
 require "inline_svg/asset_file"
 require "inline_svg/cached_asset_file"
 require "inline_svg/finds_asset_paths"
+require "inline_svg/propshaft_asset_finder"
 require "inline_svg/static_asset_finder"
 require "inline_svg/webpack_asset_finder"
 require "inline_svg/transform_pipeline"
@@ -41,6 +42,8 @@ module InlineSvg
     def asset_finder=(finder)
       @asset_finder = if finder.respond_to?(:find_asset)
                         finder
+                      elsif finder.class.name == "Propshaft::Assembly"
+                        InlineSvg::PropshaftAssetFinder
                       else
                         # fallback to a naive static asset finder
                         # (sprokects >= 3.0 && config.assets.precompile = false

--- a/lib/inline_svg/propshaft_asset_finder.rb
+++ b/lib/inline_svg/propshaft_asset_finder.rb
@@ -1,0 +1,15 @@
+module InlineSvg
+  class PropshaftAssetFinder
+    def self.find_asset(filename)
+      new(filename)
+    end
+
+    def initialize(filename)
+      @filename = filename
+    end
+
+    def pathname
+      ::Rails.application.assets.load_path.find(@filename).path
+    end
+  end
+end

--- a/spec/finds_asset_paths_spec.rb
+++ b/spec/finds_asset_paths_spec.rb
@@ -46,6 +46,21 @@ describe InlineSvg::FindsAssetPaths do
     end
   end
 
+  context "when propshaft finder returns an object which supports only the pathname method" do
+    it "returns fully qualified file paths from Propshaft" do
+      propshaft = double('PropshaftDouble')
+
+      expect(propshaft).to receive(:find_asset).with('some-file').
+        and_return(double(pathname: Pathname('/full/path/to/some-file')))
+
+      InlineSvg.configure do |config|
+        config.asset_finder = propshaft
+      end
+
+      expect(InlineSvg::FindsAssetPaths.by_filename('some-file')).to eq Pathname('/full/path/to/some-file')
+    end
+  end
+
   context "when webpack finder returns an object with a relative asset path" do
     it "returns the fully qualified file path" do
       webpacker = double('WebpackerDouble')


### PR DESCRIPTION
Rails 7 adds the option of using a new asset pipeline library called [Propshaft](https://github.com/rails/propshaft). It will most likely replace [Sprockets](https://github.com/rails/sprockets) in the future as the default asset pipeline for Rails as they move away from CSS compilers and JS bundlers.

This PR adds a new asset finder for Propshaft and it automatically loads it when appropriate. I've tried to make as few changes as possible because Sprockets is still the default and `inline_svg` supports many versions of Rails.