### PR TITLE
Add some documentation around configuring asset finders

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,20 @@ InlineSvg.configure do |config|
 end
 ```
 
+## Custom asset finder
+
+Similarly, an asset finder class should have a `find_asset` class method, and
+respond to a `pathname` instance method which returns the path to the file. If
+no class is configured, a default static file class will be used.
+
+A configuration example to use the Propshaft finder would look like:
+
+```ruby
+InlineSvg.configure do |config|
+  config.asset_finder = InlineSvg::PropshaftAssetFinder
+end
+```
+
 ## Caching all assets at boot time
 
 When your deployment strategy prevents dynamic asset file loading from disk it

--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ inline_svg_pack_tag(file_name, options={})
 _**Note:** The remainder of this README uses `inline_svg_tag` for examples, but the exact same principles work for `inline_svg_pack_tag`._
 
 The `file_name` can be a full path to a file, the file's basename or an `IO`
-object. The
-actual path of the file on disk is resolved using
-[Sprockets](://github.com/sstephenson/sprockets) (when available), a naive file finder (`/public/assets/...`) or in the case of `IO` objects the SVG data is read from the object.
-This means you can pre-process and fingerprint your SVG files like other Rails assets, or choose to find SVG data yourself.
+object. The actual path of the file on disk is resolved using a configurable
+finder class (Propshaft, Sprockets, Webpack) or a custom class, and will fall
+back to a naive static file finder (`/public/assets/...`) -- or in the case of
+`IO` objects the SVG data will be read from the object. This means you can
+pre-process and fingerprint your SVG files like other Rails assets, or choose to
+find SVG data yourself.
 
 Here's an example of embedding an SVG document and applying a 'class' attribute:
 

--- a/lib/inline_svg.rb
+++ b/lib/inline_svg.rb
@@ -46,7 +46,7 @@ module InlineSvg
                         InlineSvg::PropshaftAssetFinder
                       else
                         # fallback to a naive static asset finder
-                        # (sprokects >= 3.0 && config.assets.precompile = false
+                        # (sprockets >= 3.0 && config.assets.precompile = false
                         # See: https://github.com/jamesmartin/inline_svg/issues/25
                         InlineSvg::StaticAssetFinder
                       end


### PR DESCRIPTION
I was attempting to use propshaft on a Rails 7 app, and based on https://github.com/jamesmartin/inline_svg/pull/134 I assumed (incorrectly) that inline_svg would "just work" within that setup, but I think it needs to be explicitly configured to use Propshaft.

If that's correct, this is an attempt to improve the docs in that regard. If not, I must have something wrong locally.