### PR TITLE
Require activesupport prior to core_ext/string

### DIFF
--- a/lib/inline_svg.rb
+++ b/lib/inline_svg.rb
@@ -10,6 +10,7 @@ require "inline_svg/transform_pipeline"
 require "inline_svg/io_resource"
 
 require "inline_svg/railtie" if defined?(Rails)
+require 'active_support'
 require 'active_support/core_ext/string'
 require 'nokogiri'
 


### PR DESCRIPTION
When running the test suite with activesupport version 7, an
unitialized constant error for `XmlMini::IsolatedExecutionState`
is raised.

As described here:

- https://github.com/rails/rails/issues/43851
- https://github.com/rails/rails/pull/43852

The resolution for this is to first require `active_support` before
requiring `core_ext/string` so that autoloading happens correctly.


I confirmed locally that adding this new require works fine with versions back to 5.0.