### PR TITLE
fix: if file isn't found then this would be nil

### DIFF
--- a/lib/inline_svg/propshaft_asset_finder.rb
+++ b/lib/inline_svg/propshaft_asset_finder.rb
@@ -9,7 +9,7 @@ module InlineSvg
     end
 
     def pathname
-      ::Rails.application.assets.load_path.find(@filename).path
+      ::Rails.application.assets.load_path.find(@filename)&.path
     end
   end
 end


### PR DESCRIPTION
This fixes an issue where the path is nil if the file doesn't exist so it raises an error rather than showing an inline error.