### PR TITLE
Allow Propshaft assets to use fallbacks

### DIFF
--- a/lib/inline_svg/propshaft_asset_finder.rb
+++ b/lib/inline_svg/propshaft_asset_finder.rb
@@ -9,7 +9,8 @@ module InlineSvg
     end
 
     def pathname
-      ::Rails.application.assets.load_path.find(@filename).path
+      asset_path = ::Rails.application.assets.load_path.find(@filename)
+      asset_path.path unless asset_path.nil?
     end
   end
 end

--- a/spec/propshaft_asset_finder_spec.rb
+++ b/spec/propshaft_asset_finder_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../lib/inline_svg'
+
+describe InlineSvg::PropshaftAssetFinder do
+  context "when the file is not found" do
+    it "returns nil" do
+      stub_const('Rails', double('Rails').as_null_object)
+      expect(::Rails.application.assets.load_path).to receive(:find).with('some-file').and_return(nil)
+
+      expect(InlineSvg::PropshaftAssetFinder.find_asset('some-file').pathname).to be_nil
+    end
+  end
+
+  context "when the file is found" do
+    it "returns fully qualified file paths from Propshaft" do
+      stub_const('Rails', double('Rails').as_null_object)
+      asset = double('Asset')
+      expect(asset).to receive(:path).and_return(Pathname.new('/full/path/to/some-file'))
+      expect(::Rails.application.assets.load_path).to receive(:find).with('some-file').and_return(asset)
+
+      expect(InlineSvg::PropshaftAssetFinder.find_asset('some-file').pathname).to eq Pathname('/full/path/to/some-file')
+    end
+  end
+end


### PR DESCRIPTION
We're longtime `inline_svg` users, and we've really enjoyed your work on this gem. Thank you!

When running Rails 7 using Propshaft, when an asset is not found, the asset path resolver returns nil, raising an exception, even when`fallback:` is provided. This commit introduces a nil check around the asset path finder's return value, a lot like the one in `StaticAssetFinder`.

The higher-level `FindsAssetPaths` spec never calls down into the `PropshaftAssetFinder` itself, so this commit also introduces a test suite around the `PropshaftAssetFinder`.