### PR TITLE
Handling missing file when using static assets

### DIFF
--- a/lib/inline_svg/static_asset_finder.rb
+++ b/lib/inline_svg/static_asset_finder.rb
@@ -16,7 +16,8 @@ module InlineSvg
 
     def pathname
       if ::Rails.application.config.assets.compile
-        Pathname.new(::Rails.application.assets[@filename].filename)
+        asset = ::Rails.application.assets[@filename]
+        Pathname.new(asset.filename) if asset.present?
       else
         manifest = ::Rails.application.assets_manifest
         asset_path = manifest.assets[@filename]

--- a/spec/static_asset_finder_spec.rb
+++ b/spec/static_asset_finder_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../lib/inline_svg'
+
+describe InlineSvg::StaticAssetFinder do
+  context "when the file is not found" do
+    it "returns nil" do
+      stub_const('Rails', double('Rails').as_null_object)
+      expect(::Rails.application.config.assets).to receive(:compile).and_return(true)
+
+      expect(described_class.find_asset('some-file').pathname).to be_nil
+    end
+  end
+
+  context "when the file is found" do
+    it "returns fully qualified file path from Sprockets" do
+      stub_const('Rails', double('Rails').as_null_object)
+      expect(::Rails.application.config.assets).to receive(:compile).and_return(true)
+      pathname = Pathname.new('/full/path/to/some-file')
+      asset = double('Asset')
+      expect(asset).to receive(:filename).and_return(pathname)
+      expect(::Rails.application.assets).to receive(:[]).with('some-file').and_return(asset)
+
+      expect(described_class.find_asset('some-file').pathname).to eq(pathname)
+    end
+  end
+end


### PR DESCRIPTION
With compiled assets, if an invalid (missing) file is passed in, an unexpected error is occurring when trying to access `filename` of a nil object.

This checks to ensure that the asset was found before accessible `filename`, and in turn the expected behaviour of raising a missing file exception or rendering a comment in HTML.