### PR TITLE
Add missing activesupport require

### DIFF
--- a/lib/inline_svg.rb
+++ b/lib/inline_svg.rb
@@ -11,6 +11,7 @@ require "inline_svg/io_resource"
 
 require "inline_svg/railtie" if defined?(Rails)
 require 'active_support'
+require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/string'
 require 'nokogiri'
 


### PR DESCRIPTION
The Rails team has been removing unnecessary requirements from the `activesupport` gem for a while now.

This commit fixes the build by adding the missing extension to test the presence of any object.