### PR TITLE
Set asset finder from callable

### DIFF
--- a/lib/inline_svg.rb
+++ b/lib/inline_svg.rb
@@ -47,9 +47,7 @@ module InlineSvg
     end
 
     def asset_finder=(finder)
-      @asset_finder = if finder.respond_to?(:call)
-                        finder
-                      elsif finder.respond_to?(:find_asset)
+      @asset_finder = if finder.respond_to?(:call) || finder.respond_to?(:find_asset)
                         finder
                       elsif finder.class.name == "Propshaft::Assembly"
                         InlineSvg::PropshaftAssetFinder

--- a/lib/inline_svg/railtie.rb
+++ b/lib/inline_svg/railtie.rb
@@ -10,14 +10,12 @@ module InlineSvg
 
     config.after_initialize do |app|
       InlineSvg.configure do |config|
-        # Configure the asset_finder:
-        # Only set this when a user-configured asset finder has not been
-        # configured already.
-        if config.asset_finder.nil?
-          # In default Rails apps, this will be a fully operational
-          # Sprockets::Environment instance
-          config.asset_finder = app.instance_variable_get(:@assets)
-        end
+        # Configure an asset finder for Rails. This will be evaluated when the
+        # first SVG is rendered, giving time to the asset pipeline to be done
+        # loading.
+        config.asset_finder = proc {
+          app.instance_variable_get(:@assets)
+        }
       end
     end
   end

--- a/lib/inline_svg/railtie.rb
+++ b/lib/inline_svg/railtie.rb
@@ -13,9 +13,7 @@ module InlineSvg
         # Configure an asset finder for Rails. This will be evaluated when the
         # first SVG is rendered, giving time to the asset pipeline to be done
         # loading.
-        config.asset_finder = proc {
-          app.instance_variable_get(:@assets)
-        }
+        config.asset_finder = proc { app.assets }
       end
     end
   end

--- a/spec/inline_svg_spec.rb
+++ b/spec/inline_svg_spec.rb
@@ -51,6 +51,16 @@ describe InlineSvg do
         expect(InlineSvg.configuration.asset_finder).to eq InlineSvg::PropshaftAssetFinder
       end
 
+      it "allows giving a callable object that returns a callable" do
+        finder = double("A custom asset finder", find_asset: "some asset")
+        callable = -> { -> { finder } }
+        InlineSvg.configure do |config|
+          config.asset_finder = callable
+        end
+
+        expect(InlineSvg.configuration.asset_finder).to eq finder
+      end
+
       it "falls back to StaticAssetFinder when the provided asset finder does not implement #find_asset" do
         InlineSvg.configure do |config|
           config.asset_finder = 'Not a real asset finder'

--- a/spec/inline_svg_spec.rb
+++ b/spec/inline_svg_spec.rb
@@ -19,6 +19,10 @@ end
 
 describe InlineSvg do
   describe "configuration" do
+    before do
+      InlineSvg.reset_configuration!
+    end
+
     context "when a block is not given" do
       it "complains" do
         expect do
@@ -29,12 +33,22 @@ describe InlineSvg do
 
     context "asset finder" do
       it "allows an asset finder to be assigned" do
-        sprockets = double('SomethingLikeSprockets', find_asset: 'some asset')
+        sprockets = double("Something like sprockets", find_asset: "some asset")
         InlineSvg.configure do |config|
           config.asset_finder = sprockets
         end
 
         expect(InlineSvg.configuration.asset_finder).to eq sprockets
+      end
+
+      it "allows to give a callable object that returns an asset finder" do
+        propshaft = double("Something like propshaft", class: double(name: "Propshaft::Assembly"))
+        callable = -> { propshaft }
+        InlineSvg.configure do |config|
+          config.asset_finder = callable
+        end
+
+        expect(InlineSvg.configuration.asset_finder).to eq InlineSvg::PropshaftAssetFinder
       end
 
       it "falls back to StaticAssetFinder when the provided asset finder does not implement #find_asset" do


### PR DESCRIPTION
It fixes #151 by allowing the asset finder to be a callable object. This is useful when the asset pipeline is not ready when the initializer is run, for example, when using Propshaft.

I don't know if this is the best way to solve this problem. On the one hand, Propshaft could be done when its initializer is run, but on the other hand, this gem's railtie assumes the asset pipeline is ready.