### PR TITLE
Change asset finder configuration

### DIFF
--- a/lib/inline_svg.rb
+++ b/lib/inline_svg.rb
@@ -86,7 +86,7 @@ module InlineSvg
     private
 
     def detect_asset_finder
-      ASSET_FINDERS.find do |klass|
+      ASSET_FINDERS.detect do |klass|
         asset_finder = klass.new
         break asset_finder if asset_finder.match?
       rescue NameError

--- a/lib/inline_svg.rb
+++ b/lib/inline_svg.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/delegation'
+
 require "inline_svg/version"
 require "inline_svg/action_view/helpers"
 require "inline_svg/asset_file"
@@ -88,7 +90,11 @@ module InlineSvg
     end
 
     def matching_asset_finder
-      ASSET_FINDERS.detect(&:match?)
+      ASSET_FINDERS.find do |klass|
+        asset_finder = klass.new
+        break asset_finder if asset_finder.match?
+      rescue NameError
+      end
     end
   end
 

--- a/lib/inline_svg.rb
+++ b/lib/inline_svg.rb
@@ -61,7 +61,7 @@ module InlineSvg
     end
 
     def asset_finder
-      @asset_finder ||= matching_asset_finder
+      @asset_finder ||= detect_asset_finder
     end
 
     def svg_not_found_css_class=(css_class)
@@ -85,16 +85,16 @@ module InlineSvg
 
     private
 
-    def incompatible_transformation?(klass)
-      !klass.is_a?(Class) || !klass.respond_to?(:create_with_value) || !klass.instance_methods.include?(:transform)
-    end
-
-    def matching_asset_finder
+    def detect_asset_finder
       ASSET_FINDERS.find do |klass|
         asset_finder = klass.new
         break asset_finder if asset_finder.match?
       rescue NameError
       end
+    end
+
+    def incompatible_transformation?(klass)
+      !klass.is_a?(Class) || !klass.respond_to?(:create_with_value) || !klass.instance_methods.include?(:transform)
     end
   end
 

--- a/lib/inline_svg/propshaft_asset_finder.rb
+++ b/lib/inline_svg/propshaft_asset_finder.rb
@@ -1,25 +1,37 @@
 module InlineSvg
   class PropshaftAssetFinder
-    def self.assets
-      Rails.application.assets
+    class Asset
+      attr_reader :asset_finder, :filename
+
+      def initialize(filename, asset_finder)
+        @asset_finder = asset_finder
+        @filename = filename
+      end
+
+      delegate :assets, to: :asset_finder
+
+      def pathname
+        asset_path = assets.load_path.find(@filename)
+        asset_path&.path
+      end
     end
 
-    def self.find_asset(filename)
-      new(filename)
+    attr_reader :assets
+
+    def initialize(assets = ::Rails.application.assets)
+      @assets = assets
     end
 
-    def self.match?
-      assets.instance_of?(Propshaft::Assembly)
-    rescue NameError
+    class << self
+      delegate :find_asset, to: :new
     end
 
-    def initialize(filename)
-      @filename = filename
+    def find_asset(filename)
+      Asset.new(filename, self)
     end
 
-    def pathname
-      asset_path = self.class.assets.load_path.find(@filename)
-      asset_path&.path
+    def match?
+      defined?(::Propshaft) && assets.instance_of?(Propshaft::Assembly)
     end
   end
 end

--- a/lib/inline_svg/propshaft_asset_finder.rb
+++ b/lib/inline_svg/propshaft_asset_finder.rb
@@ -1,7 +1,16 @@
 module InlineSvg
   class PropshaftAssetFinder
+    def self.assets
+      Rails.application.assets
+    end
+
     def self.find_asset(filename)
       new(filename)
+    end
+
+    def self.match?
+      assets.instance_of?(Propshaft::Assembly)
+    rescue NameError
     end
 
     def initialize(filename)
@@ -9,8 +18,8 @@ module InlineSvg
     end
 
     def pathname
-      asset_path = ::Rails.application.assets.load_path.find(@filename)
-      asset_path.path unless asset_path.nil?
+      asset_path = self.class.assets.load_path.find(@filename)
+      asset_path&.path
     end
   end
 end

--- a/lib/inline_svg/railtie.rb
+++ b/lib/inline_svg/railtie.rb
@@ -7,18 +7,5 @@ module InlineSvg
         include InlineSvg::ActionView::Helpers
       end
     end
-
-    config.after_initialize do |app|
-      InlineSvg.configure do |config|
-        # Configure the asset_finder:
-        # Only set this when a user-configured asset finder has not been
-        # configured already.
-        if config.asset_finder.nil?
-          # In default Rails apps, this will be a fully operational
-          # Sprockets::Environment instance
-          config.asset_finder = app.instance_variable_get(:@assets)
-        end
-      end
-    end
   end
 end

--- a/lib/inline_svg/sprockets_asset_finder.rb
+++ b/lib/inline_svg/sprockets_asset_finder.rb
@@ -1,16 +1,19 @@
 module InlineSvg
-  module SprocketsAssetFinder
-    def self.assets
-      Rails.application.assets
+  class SprocketsAssetFinder
+    attr_reader :assets
+
+    def initialize(assets = ::Rails.application.assets)
+      @assets = assets
     end
 
-    def self.find_asset(*args, **options)
-      assets.find_asset(*args, **options)
+    class << self
+      delegate :find_asset, to: :new
     end
 
-    def self.match?
+    delegate :find_asset, to: :assets
+
+    def match?
       assets.respond_to?(:find_asset)
-    rescue NameError
     end
   end
 end

--- a/lib/inline_svg/sprockets_asset_finder.rb
+++ b/lib/inline_svg/sprockets_asset_finder.rb
@@ -1,0 +1,16 @@
+module InlineSvg
+  module SprocketsAssetFinder
+    def self.assets
+      Rails.application.assets
+    end
+
+    def self.find_asset(*args, **options)
+      assets.find_asset(*args, **options)
+    end
+
+    def self.match?
+      assets.respond_to?(:find_asset)
+    rescue NameError
+    end
+  end
+end

--- a/lib/inline_svg/static_asset_finder.rb
+++ b/lib/inline_svg/static_asset_finder.rb
@@ -10,6 +10,10 @@ module InlineSvg
       new(filename)
     end
 
+    def self.match?
+      true
+    end
+
     def initialize(filename)
       @filename = filename
     end

--- a/lib/inline_svg/static_asset_finder.rb
+++ b/lib/inline_svg/static_asset_finder.rb
@@ -9,7 +9,7 @@ module InlineSvg
     class Asset
       attr_reader :filename
 
-      def initialize(filename, _asset_finder)
+      def initialize(filename)
         @filename = filename
       end
 
@@ -32,7 +32,7 @@ module InlineSvg
     end
 
     def find_asset(filename)
-      Asset.new(filename, self)
+      Asset.new(filename)
     end
 
     def match?

--- a/lib/inline_svg/static_asset_finder.rb
+++ b/lib/inline_svg/static_asset_finder.rb
@@ -6,29 +6,37 @@ require "pathname"
 # https://github.com/jamesmartin/inline_svg/commit/661bbb3bef7d1b4bd6ccd63f5f018305797b9509
 module InlineSvg
   class StaticAssetFinder
-    def self.find_asset(filename)
-      new(filename)
-    end
+    class Asset
+      attr_reader :filename
 
-    def self.match?
-      true
-    end
+      def initialize(filename, _asset_finder)
+        @filename = filename
+      end
 
-    def initialize(filename)
-      @filename = filename
-    end
-
-    def pathname
-      if ::Rails.application.config.assets.compile
-        asset = ::Rails.application.assets[@filename]
-        Pathname.new(asset.filename) if asset.present?
-      else
-        manifest = ::Rails.application.assets_manifest
-        asset_path = manifest.assets[@filename]
-        unless asset_path.nil?
-          ::Rails.root.join(manifest.directory, asset_path)
+      def pathname
+        if ::Rails.application.config.assets.compile
+          asset = ::Rails.application.assets[@filename]
+          Pathname.new(asset.filename) if asset.present?
+        else
+          manifest = ::Rails.application.assets_manifest
+          asset_path = manifest.assets[@filename]
+          unless asset_path.nil?
+            ::Rails.root.join(manifest.directory, asset_path)
+          end
         end
       end
+    end
+
+    class << self
+      delegate :find_asset, to: :new
+    end
+
+    def find_asset(filename)
+      Asset.new(filename, self)
+    end
+
+    def match?
+      defined?(::Rails)
     end
   end
 end

--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -7,7 +7,7 @@ module InlineSvg
     def initialize(filename)
       @filename = filename
       manifest_lookup = Webpacker.manifest.lookup(@filename)
-      @asset_path =  manifest_lookup.present? ? URI(manifest_lookup).path : ""
+      @asset_path = manifest_lookup.present? ? URI(manifest_lookup).path : ""
     end
 
     def pathname
@@ -31,7 +31,7 @@ module InlineSvg
           file.write(asset)
           file.rewind
         end
-      rescue StandardError => e
+      rescue => e
         Rails.logger.error "[inline_svg] Error creating tempfile for #{@filename}: #{e}"
         raise
       end
@@ -43,7 +43,7 @@ module InlineSvg
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
       http.request(Net::HTTP::Get.new(file_path)).body
-    rescue StandardError => e
+    rescue => e
       Rails.logger.error "[inline_svg] Error fetching #{@filename} from webpack-dev-server: #{e}"
       raise
     end

--- a/spec/inline_svg_spec.rb
+++ b/spec/inline_svg_spec.rb
@@ -34,7 +34,7 @@ describe InlineSvg do
           stub_const("Rails", double("Rails"))
           allow(Rails).to receive_message_chain(:application, :assets).and_return(sprockets)
 
-          expect(InlineSvg.configuration.asset_finder).to eq InlineSvg::SprocketsAssetFinder
+          expect(InlineSvg.configuration.asset_finder).to be_a InlineSvg::SprocketsAssetFinder
         end
       end
 
@@ -44,13 +44,16 @@ describe InlineSvg do
           stub_const("Rails", double("Rails"))
           allow(Rails).to receive_message_chain(:application, :assets).and_return(Propshaft::Assembly.new)
 
-          expect(InlineSvg.configuration.asset_finder).to eq InlineSvg::PropshaftAssetFinder
+          expect(InlineSvg.configuration.asset_finder).to be_a InlineSvg::PropshaftAssetFinder
         end
       end
 
       context "when Sprockets and Propshaft are not detected" do
         it "uses the static asset finder" do
-          expect(InlineSvg.configuration.asset_finder).to eq InlineSvg::StaticAssetFinder
+          stub_const("Rails", double("Rails"))
+          allow(Rails).to receive_message_chain(:application, :assets).and_return(nil)
+
+          expect(InlineSvg.configuration.asset_finder).to be_a InlineSvg::StaticAssetFinder
         end
       end
 

--- a/spec/sprockets_asset_finder_spec.rb
+++ b/spec/sprockets_asset_finder_spec.rb
@@ -1,0 +1,11 @@
+require_relative "../lib/inline_svg"
+
+describe InlineSvg::SprocketsAssetFinder do
+  it "returns assets from Sprockets" do
+    sprockets = double("Sprockets", find_asset: "some asset")
+    stub_const("Rails", double("Rails"))
+    allow(Rails).to receive_message_chain(:application, :assets).and_return(sprockets)
+
+    expect(described_class.find_asset("some-file")).to eq "some asset"
+  end
+end


### PR DESCRIPTION
This commit changes the way the asset finder is configured. Instead of setting the asset finder from an initializer to a specific class, the asset finder is now detected unless configured otherwise.

This allows InlineSvg to work with Sprockets, Propshaft, or a fallback static asset finder without any configuration.