### PR TITLE
Add support to Shakapacker

### DIFF
--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -6,21 +6,30 @@ module InlineSvg
 
     def initialize(filename)
       @filename = filename
-      manifest_lookup = Webpacker.manifest.lookup(@filename)
+      manifest_lookup = asset_helper.manifest.lookup(@filename)
       @asset_path =  manifest_lookup.present? ? URI(manifest_lookup).path : ""
     end
 
     def pathname
       return if @asset_path.blank?
 
-      if Webpacker.dev_server.running?
+      if asset_helper.dev_server.running?
         dev_server_asset(@asset_path)
-      elsif Webpacker.config.public_path.present?
-        File.join(Webpacker.config.public_path, @asset_path)
+      elsif asset_helper.config.public_path.present?
+        File.join(asset_helper.config.public_path, @asset_path)
       end
     end
 
     private
+
+    def asset_helper
+      @asset_helper ||=
+        if defined?(::Shakapacker)
+          ::Shakapacker
+        else
+          ::Webpacker
+        end
+    end
 
     def dev_server_asset(file_path)
       asset = fetch_from_dev_server(file_path)
@@ -38,8 +47,8 @@ module InlineSvg
     end
 
     def fetch_from_dev_server(file_path)
-      http = Net::HTTP.new(Webpacker.dev_server.host, Webpacker.dev_server.port)
-      http.use_ssl = Webpacker.dev_server.https?
+      http = Net::HTTP.new(asset_helper.dev_server.host, asset_helper.dev_server.port)
+      http.use_ssl = asset_helper.dev_server.protocol == "https"
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
       http.request(Net::HTTP::Get.new(file_path)).body

--- a/spec/webpack_asset_finder_spec.rb
+++ b/spec/webpack_asset_finder_spec.rb
@@ -10,4 +10,14 @@ describe InlineSvg::WebpackAssetFinder do
       expect(described_class.find_asset('some-file').pathname).to be_nil
     end
   end
+
+  context "when Shakapacker is defined" do
+    it "uses the new spelling" do
+      stub_const('Rails', double('Rails').as_null_object)
+      stub_const('Shakapacker', double('Shakapacker').as_null_object)
+      expect(::Shakapacker.manifest).to receive(:lookup).with('some-file').and_return(nil)
+
+      expect(described_class.find_asset('some-file').pathname).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Shakapacker is the official, actively maintained successor to Webpacker.

Shakapacker v7 changed the spelling of `Webpacker` to `Shakapacker` in
the entire project, but still provided backward compatibility for
`Webpacker` spelling.

v8 dropped the deprecated spelling

This commit also:
- Checks if `Shakapacker` is defined; if not, it falls back on
  `Webpacker`.
- Uses the scope resolution operator to resolve at top-level
  scope
- Checks `protocol` instead of `https?` because the former is available
  from Webpacker 3 and the latter is not available anymore in
  Shakapacker >= 8

Refs:
- shakacode/shakapacker#414
- shakacode/shakapacker#429
- shakacode/shakapacker#486

Close jamesmartin#156