### PR TITLE
Use `File::NULL` instead of hardcoded `/dev/null`

### DIFF
--- a/spec/io_resource_spec.rb
+++ b/spec/io_resource_spec.rb
@@ -69,7 +69,7 @@ describe InlineSvg::IOResource do
       let(:file_path) { File.expand_path('files/example.svg', __dir__) }
       let(:answer) { File.read(file_path) }
       let(:rio) { File.new(file_path, 'r') }
-      let(:wio) { File.new('/dev/null', 'w') }
+      let(:wio) { File.new(File::NULL, 'w') }
 
       instance_exec(&tests)
       it 'has non empty body' do


### PR DESCRIPTION
Allow to run specs in file systems where `/dev/null` is not supported, like Windows.

Tested on GitHub Actions, with `runs-on: windows-latest`

---

### Before

https://github.com/tagliala/inline_svg/actions/runs/11981009383

### After

https://github.com/tagliala/inline_svg/actions/runs/11981044155