### PR TITLE
Fix unused variables warnings

### DIFF
--- a/spec/cached_asset_file_spec.rb
+++ b/spec/cached_asset_file_spec.rb
@@ -48,7 +48,6 @@ describe InlineSvg::CachedAssetFile do
   end
 
   it "filters wanted files by simple string matching" do
-    known_document_0 = File.read(fixture_path.join("assets0", "known-document.svg"))
     known_document_1 = File.read(fixture_path.join("assets1", "known-document.svg"))
 
     asset_loader = InlineSvg::CachedAssetFile.new(paths: fixture_path, filters: "assets1")

--- a/spec/transformation_pipeline/transformations/transformation_spec.rb
+++ b/spec/transformation_pipeline/transformations/transformation_spec.rb
@@ -25,7 +25,7 @@ describe InlineSvg::TransformPipeline::Transformations::Transformation do
         returned_document = transformation.with_svg(document, &b)
       end.to yield_control
 
-      expect(returned_document.to_s).to match(%r{<svg>Some document</svg>})
+      expect(returned_document.to_s).to match(svg)
     end
 
     it "does not yield if the document does not contain an SVG element at the root" do


### PR DESCRIPTION
Fix the following warnings:

```
spec/cached_asset_file_spec.rb:51: warning: assigned but unused variable - known_document_0
spec/transformation_pipeline/transformations/transformation_spec.rb:19: warning: assigned but unused variable - svg
```