### PR TITLE
Test against Ruby 3.4 and fix CI

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.3']
+        ruby-version: ['3.4']
 
     continue-on-error: ${{ matrix.channel != 'stable' }}
 
@@ -24,8 +24,8 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
     - name: Test with Rake
       run: |
-        bundle exec rubocop
+        bundle exec rubocop --format github

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3']
+        ruby-version: ['3.1', '3.2', '3.3', '3.4']
         channel: ['stable']
 
         include:
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
     - name: Test with Rake
       run: |

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_from: .rubocop_todo.yml
 
-require:
+plugins:
   - rubocop-packaging
   - rubocop-performance
   - rubocop-rake

--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,10 @@ gem "pry"
 gem "rake"
 gem "rspec"
 
-gem "rubocop", "1.69.2", require: false
-gem "rubocop-packaging", "0.5.2", require: false
-gem "rubocop-performance", "1.23.0", require: false
-gem "rubocop-rake", "0.6.0", require: false
-gem "rubocop-rspec", "3.3.0", require: false
+gem "rubocop", "1.75.3", require: false
+gem "rubocop-packaging", "0.6.0", require: false
+gem "rubocop-performance", "1.25.0", require: false
+gem "rubocop-rake", "0.7.1", require: false
+gem "rubocop-rspec", "3.6.0", require: false
 
 gem "simplecov", require: false

--- a/spec/finds_asset_paths_spec.rb
+++ b/spec/finds_asset_paths_spec.rb
@@ -86,13 +86,13 @@ RSpec.describe InlineSvg::FindsAssetPaths do
       shakapacker = double('ShakapackerDouble')
 
       expect(shakapacker).to receive(:find_asset).with('some-file')
-                                                 .and_return(double(filename: Pathname('https://my-fancy-domain.test/full/path/to/some-file')))
+                                                 .and_return(double(filename: Pathname('https://test.example.org/full/path/to/some-file')))
 
       InlineSvg.configure do |config|
         config.asset_finder = shakapacker
       end
 
-      expect(InlineSvg::FindsAssetPaths.by_filename('some-file')).to eq Pathname('https://my-fancy-domain.test/full/path/to/some-file')
+      expect(InlineSvg::FindsAssetPaths.by_filename('some-file')).to eq Pathname('https://test.example.org/full/path/to/some-file')
     end
   end
 end

--- a/spec/helpers/inline_svg_spec.rb
+++ b/spec/helpers/inline_svg_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe InlineSvg::ActionView::Helpers do
   let(:helper) { (Class.new { include InlineSvg::ActionView::Helpers }).new }
 
   shared_examples "inline_svg helper" do |helper_method:|
-    context "when passed the name of an SVG that does not exist" do
-      after do
-        InlineSvg.reset_configuration!
-      end
+    after do
+      InlineSvg.reset_configuration!
+    end
 
+    context "when passed the name of an SVG that does not exist" do
       context "and configured to raise" do
         before do
           InlineSvg.configure do |config|
@@ -166,10 +166,6 @@ RSpec.describe InlineSvg::ActionView::Helpers do
           end
         end
 
-        after do
-          InlineSvg.reset_configuration!
-        end
-
         it "applies custm transformations to the output" do
           input_svg = '<svg></svg>'
           expected_output = '<svg custom="some value"></svg>'
@@ -183,10 +179,6 @@ RSpec.describe InlineSvg::ActionView::Helpers do
           InlineSvg.configure do |config|
             config.add_custom_transformation({ attribute: :custom, transform: WorkingCustomTransform, default_value: 'default value' })
           end
-        end
-
-        after do
-          InlineSvg.reset_configuration!
         end
 
         context "without passing the attribute value" do


### PR DESCRIPTION
### Requires:
- [x] #185

---

- Test against Ruby 3.4
- Make sure to run CI against different Ruby versions instead of 3.3
- Pluginify RuboCop config

Additionally:
- Update RuboCop dependencies
- Use GitHub formatter for RuboCop action
- Use an example test domain to prevent information disclosure
- Ensure "reset configuration" is used when configuration is changed

---

### Before

![image](https://github.com/user-attachments/assets/5ea566a8-b704-440b-b23a-9affbdef4647)
