### PR TITLE
Prevent thread-local variable leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Drop Support for Webpacker, Legacy Ruby (< 3.1), and Legacy Rails (< 7.0). [#163](https://github.com/jamesmartin/inline_svg/pull/163). Thanks, [@tagliala](https://github.com/tagliala)
 - Reduce production gem size from 31K to 18K. [#165](https://github.com/jamesmartin/inline_svg/pull/165). Thanks, [@tagliala](https://github.com/tagliala)
 - Freeze string literals. [#172](https://github.com/jamesmartin/inline_svg/pull/172). Thanks, [@tagliala](https://github.com/tagliala)
+- Fix thread-local variable leakage in `with_asset_finder`. [#185](https://github.com/jamesmartin/inline_svg/pull/185). Thanks, [@tagliala](https://github.com/tagliala)
 
 ## [1.10.0] - 2024-09-03
 ### Added

--- a/lib/inline_svg/action_view/helpers.rb
+++ b/lib/inline_svg/action_view/helpers.rb
@@ -68,10 +68,9 @@ module InlineSvg
 
       def with_asset_finder(asset_finder)
         Thread.current[:inline_svg_asset_finder] = asset_finder
-        output = yield
+        yield
+      ensure
         Thread.current[:inline_svg_asset_finder] = nil
-
-        output
       end
 
       def extension_hint(filename)


### PR DESCRIPTION
Previously, if the block passed to `with_asset_finder` raised an exception, the thread-local variable `:inline_svg_asset_finder` was not cleared, leading to potential leakage across threads.

This change ensures that the variable is always cleared using an `ensure` block, even if an error occurs.

Close #184