### PR TITLE
Fix #144. Add support for Tempfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Freeze string literals. [#172](https://github.com/jamesmartin/inline_svg/pull/172). Thanks, [@tagliala](https://github.com/tagliala)
 - Fix thread-local variable leakage in `with_asset_finder`. [#185](https://github.com/jamesmartin/inline_svg/pull/185). Thanks, [@tagliala](https://github.com/tagliala)
 - Remove unused `InlineSvg::IOResource.default_for` method. [#187](https://github.com/jamesmartin/inline_svg/pull/187). Thanks, [@tagliala](https://github.com/tagliala)
+- Add support for Tempfile. [#186](https://github.com/jamesmartin/inline_svg/pull/186). Thanks, [@javierav](https://github.com/javierav)
 
 ## [1.10.0] - 2024-09-03
 ### Added

--- a/README.md
+++ b/README.md
@@ -315,6 +315,12 @@ InlineSvg.configure do |config|
 end
 ```
 
+## ActiveStorage
+
+```erb
+<%= user.avatar.open { |file| inline_svg_tag file } %>
+```
+
 ## Contributing
 
 1. Fork it ( [http://github.com/jamesmartin/inline_svg/fork](http://github.com/jamesmartin/inline_svg/fork) )

--- a/lib/inline_svg/io_resource.rb
+++ b/lib/inline_svg/io_resource.rb
@@ -3,7 +3,7 @@
 module InlineSvg
   module IOResource
     def self.===(object)
-      object.is_a?(IO) || object.is_a?(StringIO)
+      object.is_a?(IO) || object.is_a?(StringIO) || object.is_a?(Tempfile)
     end
 
     def self.read(object)

--- a/spec/io_resource_spec.rb
+++ b/spec/io_resource_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe InlineSvg::IOResource do
       it "for File object" do
         expect(subject === File.new("#{Dir.tmpdir}/testfile", "w")).to be true
       end
+
+      it "for Tempfile object" do
+        expect(subject === Tempfile.new).to be true
+      end
     end
 
     context 'return false' do
@@ -77,6 +81,19 @@ RSpec.describe InlineSvg::IOResource do
       it 'has non empty body' do
         expect(answer).not_to eq ''
       end
+    end
+
+    context 'Tempfile object' do
+      let(:answer) { 'read' }
+      let(:rio) do
+        Tempfile.new.tap do |f|
+          f.write(answer)
+          f.rewind
+        end
+      end
+      let(:wio) { File.new(File::NULL, 'w') } # Tempfile cannot be created for write only mode
+
+      instance_exec(&tests)
     end
   end
 end


### PR DESCRIPTION
If we want to use this gem with an SVG stored in Active Storage, we have to temporarily download the file and then use it with gem helper

```ruby
module SvgHelper
  def remote_svg(blob, **)
    blob.open do |file|
      inline_svg_tag file, **
    end
  end
end

# in views
<%= remote_svg(user.icon) %>
```

The problem is that Active Storage uses a temporary file with the `Tempfile` class that uses `DelegateClass` over `File`, so technically it behaves like a `File` but does not inherit from it, so it could not be used with this gem.

This PR fixes that issue by providing support for `Tempfile`.