### PR TITLE
Remove unused `IOResource.default_for` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Reduce production gem size from 31K to 18K. [#165](https://github.com/jamesmartin/inline_svg/pull/165). Thanks, [@tagliala](https://github.com/tagliala)
 - Freeze string literals. [#172](https://github.com/jamesmartin/inline_svg/pull/172). Thanks, [@tagliala](https://github.com/tagliala)
 - Fix thread-local variable leakage in `with_asset_finder`. [#185](https://github.com/jamesmartin/inline_svg/pull/185). Thanks, [@tagliala](https://github.com/tagliala)
+- Remove unused `InlineSvg::IOResource.default_for` method. [#187](https://github.com/jamesmartin/inline_svg/pull/187). Thanks, [@tagliala](https://github.com/tagliala)
 
 ## [1.10.0] - 2024-09-03
 ### Added

--- a/lib/inline_svg/io_resource.rb
+++ b/lib/inline_svg/io_resource.rb
@@ -6,13 +6,6 @@ module InlineSvg
       object.is_a?(IO) || object.is_a?(StringIO)
     end
 
-    def self.default_for(object)
-      case object
-      when StringIO then ''
-      when IO then 1
-      end
-    end
-
     def self.read(object)
       start = object.pos
       str = object.read


### PR DESCRIPTION
This method, introduced in the 4b13f77 commit along with the IOResource class, is not utilized in either production or test code.

To the best of my understanding, this discrepancy may be attributed to a copy-and-paste error.

Ref: #186