### PR TITLE
Add inline_svg_data_url helper to return SVG as base64 data URL

### DIFF
--- a/lib/inline_svg/action_view/helpers.rb
+++ b/lib/inline_svg/action_view/helpers.rb
@@ -2,6 +2,7 @@
 
 require 'action_view/helpers' if defined?(Rails)
 require 'action_view/context' if defined?(Rails)
+require 'base64'
 
 module InlineSvg
   module ActionView
@@ -20,6 +21,14 @@ module InlineSvg
 
       def inline_svg(filename, transform_params = {})
         render_inline_svg(filename, transform_params)
+      end
+
+      def inline_svg_data_url(filename, transform_params = {})
+        svg = render_inline_svg(filename, transform_params)
+        svg = svg.sub(/<\?xml.*?\?>/, "").strip
+        svg = svg.gsub(/\s+/, " ")
+        base64 = Base64.strict_encode64(svg)
+        "data:image/svg+xml;base64,#{base64}"
       end
 
       private


### PR DESCRIPTION
This PR introduces a new helper method, `inline_svg_data_url`, to the `InlineSvg::ActionView::Helpers module.
It allows users to render an SVG and return its content as a base64-encoded data URL, suitable for embedding directly in HTML or CSS.

- Reuses all existing SVG transformations and asset lookup logic.
- Removes XML declaration and minifies whitespace before encoding.
- Includes dedicated tests for the new method.

This feature addresses [issue #169](https://github.com/jamesmartin/inline_svg/issues/169), which requested support for returning SVGs as data URLs for use in CSS and other scenarios.

No breaking changes; all existing helpers and tests remain unchanged.

The new helper was tested in the [basic Rails app](https://github.com/jamesmartin/inline_svg_test_app)) and works as expected.

```html
<h2>Using SVG as background image</h2>
<div class="size-sm svg-background" style="--svg-background-image: url('<%= inline_svg_data_url("iconmonstr-glasses-12-icon.svg") %>');"></div>
<div class="size-sm svg-background" style="--svg-background-image: url('<%= inline_svg_data_url("iconmonstr-glasses-12-icon.svg", style: "fill: green;") %>');"></div>
<div class="size-sm svg-background" style="--svg-background-image: url('<%= inline_svg_data_url("iconmonstr-glasses-12-icon.svg", style: "fill: red;") %>');"></div>
```

```css
.svg-background {
  background-image: var(--svg-background-image);
  background-size: cover;
}

.size-sm {
  width: 5em;
  height: 5em;
}
```

With this new helper, it’s now possible to use SVGs from your Rails app directly as CSS background images, or anywhere a data URL is accepted.
Additionally, because the helper supports all existing transformation options, you can easily customize aspects of the SVG—such as color, size, or other attributes—before encoding, making it flexible for dynamic styling and theming.